### PR TITLE
Update Dockerfile directory handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
 # Copy the source code into the container
 COPY src/ ./src
 COPY ultralytics/ ./ultralytics
-COPY datasets/ ./datasets
 COPY weights/ ./weights
-COPY tempDir/ ./tempDir
-COPY output/ ./output
+
+# Create necessary directories
+RUN mkdir -p datasets tempDir output
 
 # Set default environment variables
 ENV RUN_MODE=streamlit


### PR DESCRIPTION
## Summary
- create output folders inside Dockerfile
- stop copying local datasets
- keep weights copy

## Testing
- `flake8 src` *(fails: command not found)*
- `mypy src` *(fails: missing dependencies)*
- `python -m build` *(fails: No module named build)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861184fed7c832c908d9c651cc63ef1