### PR TITLE
Fix job result references in CI workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -195,9 +195,9 @@ jobs:
       run: |
         if [ "${{ needs.test.result }}" == "success" ] && \
            [ "${{ needs.security.result }}" == "success" ] && \
-           [ "${{ needs.build-docs.result }}" == "success" ] && \
-           [ "${{ needs.validate-config.result }}" == "success" ] && \
-           [ "${{ needs.integration-test.result }}" == "success" ]; then
+           [ "${{ needs['build-docs'].result }}" == "success" ] && \
+           [ "${{ needs['validate-config'].result }}" == "success" ] && \
+           [ "${{ needs['integration-test'].result }}" == "success" ]; then
           echo "✅ All checks passed successfully!"
         else
           echo "❌ Some checks failed. Please review the logs."


### PR DESCRIPTION
## Summary
- fix `needs` references with hyphenated job IDs in `python-test.yml`

## Testing
- `pytest tests/ -q`
- `pytest tests/ --cov=src --cov-report=term-missing` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68611e47f96c832cb00fa4706cc35e7f