### PR TITLE
Improve detection result summary

### DIFF
--- a/src/naming_config.py
+++ b/src/naming_config.py
@@ -353,6 +353,7 @@ IMAGE_DISPLAY_LABELS = {
 # 统计信息标签
 STATISTICS_LABELS = {
     "total_images_info": "共有 {count} 张检测结果图片",
+    "total_images_failed_info": "共有 {count} 张检测结果图片，检测失败 {failed} 张",
     "image_index_info": "**第 {current} / {total} 张图片**",
     "filename_info": "文件名: {filename}",
     "total_files": "📊 总文件数",

--- a/src/web.py
+++ b/src/web.py
@@ -2708,7 +2708,15 @@ class Detection_UI:
 
         if len(saved_images_ini) > 0:
             total_imgs = len(saved_images_ini)
-            st.info(get_statistic_message("total_images_info", count=total_imgs))
+            failed = st.session_state.get("failed_count", 0)
+            if failed > 0:
+                st.info(
+                    get_statistic_message(
+                        "total_images_failed_info", count=total_imgs, failed=failed
+                    )
+                )
+            else:
+                st.info(get_statistic_message("total_images_info", count=total_imgs))
 
             # 初始化或验证图片索引
             if "image_play_index" not in st.session_state:
@@ -3171,6 +3179,7 @@ class Detection_UI:
             st.session_state["saved_images_ini"] = self.logTable.saved_images_ini.copy()
             st.session_state["saved_images"] = self.logTable.saved_images.copy()
             st.session_state["saved_names"] = self.logTable.saved_names.copy()
+            st.session_state["failed_count"] = failed_count
             # 同步每张图片的目标信息
             if hasattr(self.logTable, "saved_targets_info"):
                 st.session_state["saved_targets_info"] = self.logTable.saved_targets_info.copy()
@@ -3297,6 +3306,7 @@ class Detection_UI:
                     )
                 )
 
+                st.session_state["failed_count"] = 0
                 st.success(get_detection_message("single_image_complete"))
                 # 立即刷新页面，让selectbox自动更新
                 st.rerun()


### PR DESCRIPTION
## Summary
- add a new label for showing failed detection count
- display failed image count in main UI
- store failed count during batch and single image runs

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement flake8>=6.0.0)*
- `flake8 src` *(fails: command not found)*
- `mypy src` *(fails with missing stubs)*
- `pytest tests/ --cov=src --cov-report=term-missing` *(fails: unrecognized arguments --cov=src)*

------
https://chatgpt.com/codex/tasks/task_e_686a255bda2c832cb2e097239b869708