### PR TITLE
Add segmentation inclusion relationship option

### DIFF
--- a/src/naming_config.py
+++ b/src/naming_config.py
@@ -118,6 +118,7 @@ SIDEBAR_LABELS = {
     "rtsp_output_url": "RTSP输出地址",
     # GPS经纬度设置
     "enable_gps_parsing": "解析并显示经纬度",
+    "show_inclusion_relationship": "显示包含关系表",
 }
 
 # 侧边栏选项配置
@@ -169,6 +170,7 @@ SIDEBAR_HINTS = {
     "rtsp_output_hint": "💡 提示: 输入RTSP/RTMP推流地址，用于实时推送检测结果视频流。",
     "clear_files_success": "已清空所有上传的文件！",
     "gps_parsing_hint": "💡 提示: 勾选后将解析图片的RTK GPS信息，在主页面与导出的报表中显示。",
+    "inclusion_relationship_hint": "💡 提示: 统计每个组串包含的单组件数量",
 }
 
 # =============================================================================
@@ -185,6 +187,7 @@ MAIN_HEADERS = {
     "gps_info": "🛰️ GPS 信息",
     "image_preprocessing_preview": "🖼️ 图片预处理预览",
     "current_category_statistics": "📊 当前类别统计",
+    "inclusion_relationship": "🔗 包含关系表",
     "total_category_statistics": "📈 总体类别统计",
     # 调试相关
     "current_config": "当前配置",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,17 +1,17 @@
+import io
 import os
+from hashlib import md5
+from pathlib import Path
 
 import cv2
+import exifread
 import numpy as np
 import pandas as pd
-from PIL import ImageFont, ImageDraw, Image
-from PIL.ExifTags import TAGS, GPSTAGS
-import exifread
-from hashlib import md5
-from QtFusion.path import abs_path
 from matplotlib.colors import LinearSegmentedColormap
-from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
+from PIL.ExifTags import GPSTAGS, TAGS
+from QtFusion.path import abs_path
 from scipy.optimize import minimize
-import io
 
 
 class LocalFileObj(io.BytesIO):
@@ -19,6 +19,7 @@ class LocalFileObj(io.BytesIO):
         with open(file_path, "rb") as f:
             super().__init__(f.read())
         self.name = os.path.basename(file_path)
+
 
 def save_uploaded_file(uploaded_file):
     """
@@ -66,7 +67,7 @@ def concat_results(result, location, confidence, time):
         "识别结果": [result],
         "位置": [location],
         "置信度": [confidence],
-        "用时": [time]
+        "用时": [time],
     }
 
     results_df = pd.DataFrame(result_data)
@@ -176,7 +177,15 @@ def adjust_parameter(image_size, base_size=1000):
     return max_size / base_size
 
 
-def draw_detections(image, info, color=(0, 0, 255), alpha=0.2, line_number=None, is_api=False, rectangle_bbox=False):
+def draw_detections(
+    image,
+    info,
+    color=(0, 0, 255),
+    alpha=0.2,
+    line_number=None,
+    is_api=False,
+    rectangle_bbox=False,
+):
     """
     在图像上绘制检测结果，包括边界框、类别名称和掩码（如果有）
 
@@ -188,15 +197,29 @@ def draw_detections(image, info, color=(0, 0, 255), alpha=0.2, line_number=None,
         line_number (int): 行号，用于在检测框中间绘制行号，默认为 None
         rectangle_bbox (bool): 是否绘制掩码的最小外接矩形，默认为 False
     """
-    name, bbox, conf, cls_id, mask = info['class_name'], info['bbox'], info['score'], info['class_id'], info['mask']
+    name, bbox, conf, cls_id, mask = (
+        info["class_name"],
+        info["bbox"],
+        info["score"],
+        info["class_id"],
+        info["mask"],
+    )
     adjust_param = adjust_parameter(image.shape[:2])
     spacing = int(20 * adjust_param)
 
     if mask is None:
         x1, y1, x2, y2 = bbox
         aim_frame_area = (x2 - x1) * (y2 - y1)
-        cv2.rectangle(image, (x1, y1), (x2, y2), color=color, thickness=int(5 * adjust_param))
-        image = draw_with_chinese(image, name, (x1, y1 - int(30 * adjust_param)), font_size=int(35 * adjust_param), color=color)
+        cv2.rectangle(
+            image, (x1, y1), (x2, y2), color=color, thickness=int(5 * adjust_param)
+        )
+        image = draw_with_chinese(
+            image,
+            name,
+            (x1, y1 - int(30 * adjust_param)),
+            font_size=int(35 * adjust_param),
+            color=color,
+        )
         y_offset = int(50 * adjust_param)  # 类别名称上方绘制，其下方留出空间
     else:
         mask_points = np.concatenate(mask)
@@ -206,35 +229,49 @@ def draw_detections(image, info, color=(0, 0, 255), alpha=0.2, line_number=None,
             overlay = image.copy()
             cv2.fillPoly(overlay, [mask_points.astype(np.int32)], mask_color)
             image = cv2.addWeighted(overlay, 0.3, image, 0.7, 0)
-            cv2.drawContours(image, [mask_points.astype(np.int32)], -1, color=color, thickness=int(8 * adjust_param))
+            cv2.drawContours(
+                image,
+                [mask_points.astype(np.int32)],
+                -1,
+                color=color,
+                thickness=int(8 * adjust_param),
+            )
 
             # 绘制矩形包围框（如果启用）
             if rectangle_bbox:
                 x, y, w, h = cv2.boundingRect(mask_points.astype(np.int32))
                 cv2.rectangle(
-                    image, 
-                    (x, y), 
-                    (x + w, y + h), 
-                    color=color, 
-                    thickness=int(5 * adjust_param)
+                    image,
+                    (x, y),
+                    (x + w, y + h),
+                    color=color,
+                    thickness=int(5 * adjust_param),
                 )
 
             # 计算面积、周长、圆度
             area = cv2.contourArea(mask_points.astype(np.int32))
             perimeter = cv2.arcLength(mask_points.astype(np.int32), True)
-            circularity = 4 * np.pi * area / (perimeter ** 2) if perimeter > 0 else 0
+            circularity = 4 * np.pi * area / (perimeter**2) if perimeter > 0 else 0
 
             # 计算色彩
             mask = np.zeros(image.shape[:2], dtype=np.uint8)
             cv2.drawContours(mask, [mask_points.astype(np.int32)], -1, 255, -1)
             color_points = cv2.findNonZero(mask)
-            selected_points = color_points[np.random.choice(color_points.shape[0], 5, replace=False)]
+            selected_points = color_points[
+                np.random.choice(color_points.shape[0], 5, replace=False)
+            ]
             colors = np.mean([image[y, x] for x, y in selected_points[:, 0]], axis=0)
             color_str = f"({colors[0]:.1f}, {colors[1]:.1f}, {colors[2]:.1f})"
 
             # 绘制类别名称
             x, y = np.min(mask_points, axis=0).astype(int)
-            image = draw_with_chinese(image, name, (x, y - int(30 * adjust_param)), font_size=int(35 * adjust_param), color=color)
+            image = draw_with_chinese(
+                image,
+                name,
+                (x, y - int(30 * adjust_param)),
+                font_size=int(35 * adjust_param),
+                color=color,
+            )
             y_offset = int(50 * adjust_param)  # 类别名称上方绘制，其下方留出空间
 
             # 绘制面积、周长、圆度和色彩值
@@ -252,7 +289,13 @@ def draw_detections(image, info, color=(0, 0, 255), alpha=0.2, line_number=None,
         x1, y1, x2, y2 = bbox
         center_x = int((x1 + x2) / 2)
         center_y = int((y1 + y2) / 2)
-        image = draw_with_chinese(image, str(line_number), (center_x, center_y), font_size=int(20 * adjust_param), color=color)
+        image = draw_with_chinese(
+            image,
+            str(line_number),
+            (center_x, center_y),
+            font_size=int(20 * adjust_param),
+            color=color,
+        )
 
     return image, aim_frame_area
 
@@ -327,12 +370,17 @@ def convert_to_pseudo_colorizer(image, contrast=1.0, brightness=0):
         (0.0, (128, 128, 128)),  # 最低温度：黑色
         (0.3, (128, 0, 128)),  # 低温温度：紫色
         (0.8, (255, 50, 0)),  # 高温区域：红色
-        (1.0, (255, 255, 0))  # 最高温度：黄色
+        (1.0, (255, 255, 0)),  # 最高温度：黄色
     ]
 
     # 创建自定义颜色映射
-    colors = sorted([(pos, tuple(np.array(color) / 255)) for pos, color in colors], key=lambda x: x[0])
-    colormap = LinearSegmentedColormap.from_list("custom", [(pos, color) for pos, color in colors])
+    colors = sorted(
+        [(pos, tuple(np.array(color) / 255)) for pos, color in colors],
+        key=lambda x: x[0],
+    )
+    colormap = LinearSegmentedColormap.from_list(
+        "custom", [(pos, color) for pos, color in colors]
+    )
 
     # 将图像转换为灰度图像
     image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
@@ -341,7 +389,9 @@ def convert_to_pseudo_colorizer(image, contrast=1.0, brightness=0):
     img_array = np.array(image)
 
     # 应用对比度和亮度调整
-    img_array = np.clip(img_array.astype(np.float32) * contrast + brightness, 0, 255).astype(np.uint8)
+    img_array = np.clip(
+        img_array.astype(np.float32) * contrast + brightness, 0, 255
+    ).astype(np.uint8)
 
     # 应用颜色映射
     colored_array = colormap(img_array / 255.0)[:, :, :3]  # 忽略alpha通道
@@ -365,7 +415,9 @@ def is_black_and_white(image_array):
         return
 
     # 检查每个像素的 B、G、R 通道值是否相等
-    is_bw = np.all(image_array[:, :, 0] == image_array[:, :, 1]) and np.all(image_array[:, :, 1] == image_array[:, :, 2])
+    is_bw = np.all(image_array[:, :, 0] == image_array[:, :, 1]) and np.all(
+        image_array[:, :, 1] == image_array[:, :, 2]
+    )
 
     return is_bw
 
@@ -388,10 +440,12 @@ def camera_undistortion(frame, camera_matrix=None, dist_coeffs=None):
             new_camera_mtx, roi = cv2.getOptimalNewCameraMatrix(
                 camera_matrix, dist_coeffs, (w, h), 1, (w, h)
             )
-            undistorted = cv2.undistort(frame, camera_matrix, dist_coeffs, None, new_camera_mtx)
+            undistorted = cv2.undistort(
+                frame, camera_matrix, dist_coeffs, None, new_camera_mtx
+            )
             # 可选：裁剪ROI
             x, y, w, h = roi
-            undistorted = undistorted[y:y+h, x:x+w]
+            undistorted = undistorted[y : y + h, x : x + w]
             return undistorted
         except Exception as e:
             print(f"去畸变失败: {e}")
@@ -445,19 +499,21 @@ def rotate_image(img, angle_x, angle_y, zoom_factor=1.0):
 
     # 构造 K
     f = 1.2 * max(h, w)
-    K = np.array([[f, 0, cx],
-                  [0, f, cy],
-                  [0, 0, 1]])
+    K = np.array([[f, 0, cx], [0, f, cy], [0, 0, 1]])
     K_inv = np.linalg.inv(K)
 
     # 构造 R
-    Rx = np.array([[1, 0, 0],
-                   [0, np.cos(pitch), -np.sin(pitch)],
-                   [0, np.sin(pitch),  np.cos(pitch)]])
-    
-    Rz = np.array([[np.cos(roll), -np.sin(roll), 0],
-                   [np.sin(roll),  np.cos(roll), 0],
-                   [0, 0, 1]])
+    Rx = np.array(
+        [
+            [1, 0, 0],
+            [0, np.cos(pitch), -np.sin(pitch)],
+            [0, np.sin(pitch), np.cos(pitch)],
+        ]
+    )
+
+    Rz = np.array(
+        [[np.cos(roll), -np.sin(roll), 0], [np.sin(roll), np.cos(roll), 0], [0, 0, 1]]
+    )
     R = Rz @ Rx
 
     # 透视矩阵 H
@@ -473,9 +529,7 @@ def rotate_image(img, angle_x, angle_y, zoom_factor=1.0):
     dy = cy - new_center[1, 0]
 
     # 构造平移矩阵 T
-    T = np.array([[1, 0, dx],
-                  [0, 1, dy],
-                  [0, 0, 1]])
+    T = np.array([[1, 0, dx], [0, 1, dy], [0, 0, 1]])
 
     # 加入平移补偿后的新变换矩阵
     H_corrected = T @ H
@@ -493,7 +547,9 @@ def rotate_image(img, angle_x, angle_y, zoom_factor=1.0):
         new_w, new_h = int(w * zoom_factor), int(h * zoom_factor)
         result = cv2.resize(result, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
         pad_w, pad_h = (w - new_w) // 2, (h - new_h) // 2
-        result = cv2.copyMakeBorder(result, pad_h, pad_h, pad_w, pad_w, cv2.BORDER_CONSTANT, value=[0, 0, 0])
+        result = cv2.copyMakeBorder(
+            result, pad_h, pad_h, pad_w, pad_w, cv2.BORDER_CONSTANT, value=[0, 0, 0]
+        )
 
     return result
 
@@ -505,10 +561,10 @@ def order_points(pts):
     rect = np.zeros((4, 2), dtype="float32")
     s = pts.sum(axis=1)
     diff = np.diff(pts, axis=1)
-    rect[0] = pts[np.argmin(s)]      # top-left
-    rect[2] = pts[np.argmax(s)]      # bottom-right
-    rect[1] = pts[np.argmin(diff)]   # top-right
-    rect[3] = pts[np.argmax(diff)]   # bottom-left
+    rect[0] = pts[np.argmin(s)]  # top-left
+    rect[2] = pts[np.argmax(s)]  # bottom-right
+    rect[1] = pts[np.argmin(diff)]  # top-right
+    rect[3] = pts[np.argmax(diff)]  # bottom-left
     return rect
 
 
@@ -538,6 +594,7 @@ def find_largest_valid_contour(image, scale_factor=0.1):
         return None
     largest_cnt = max(valid_cnts, key=cv2.contourArea)
     return largest_cnt
+
 
 def auto_keystone_correction(image, scale_factor=0.1, output_path=None):
     """
@@ -576,12 +633,10 @@ def auto_keystone_correction(image, scale_factor=0.1, output_path=None):
     maxWidth = int(max(widthA, widthB))
     maxHeight = int(max(heightA, heightB))
 
-    dst_pts = np.array([
-        [0, 0],
-        [maxWidth - 1, 0],
-        [maxWidth - 1, maxHeight - 1],
-        [0, maxHeight - 1]
-    ], dtype="float32")
+    dst_pts = np.array(
+        [[0, 0], [maxWidth - 1, 0], [maxWidth - 1, maxHeight - 1], [0, maxHeight - 1]],
+        dtype="float32",
+    )
 
     # 透视变换
     M = cv2.getPerspectiveTransform(box, dst_pts)
@@ -639,20 +694,23 @@ def enhance_texture(image, method="clahe"):
         # Apply Histogram Equalization
         enhanced_gray = cv2.equalizeHist(gray)
     else:
-        raise ValueError("Invalid enhancement method. Choose 'CLAHE' or 'Histogram Equalization'.")
+        raise ValueError(
+            "Invalid enhancement method. Choose 'CLAHE' or 'Histogram Equalization'."
+        )
 
     # Convert the enhanced grayscale image back to RGB format
     enhanced_rgb = cv2.cvtColor(enhanced_gray, cv2.COLOR_GRAY2BGR)
 
     return enhanced_rgb
 
+
 def extract_gps_info(image_path):
     """
     从图片EXIF信息中提取GPS经纬度信息
-    
+
     Args:
         image_path (str): 图片文件路径
-        
+
     Returns:
         dict: 包含GPS信息的字典，包括经度、纬度、高度等
     """
@@ -721,51 +779,79 @@ def extract_gps_info(image_path):
         print(f"提取GPS信息时出错: {e}")
         return None
 
+
 def format_gps_info(gps_info):
     """
     格式化GPS信息为可读的字符串
-    
+
     Args:
         gps_info (dict): GPS信息字典
-        
+
     Returns:
         str: 格式化后的GPS信息字符串
     """
     if not gps_info:
         return "未找到GPS信息"
-    
+
     parts = []
-    
+
     # 格式化纬度
-    if 'latitude' in gps_info:
+    if "latitude" in gps_info:
         lat_str = f"{gps_info['latitude']:.6f}°"
-        if 'latitude_ref' in gps_info:
+        if "latitude_ref" in gps_info:
             lat_str += f" {gps_info['latitude_ref']}"
         parts.append(f"纬度: {lat_str}")
-    
+
     # 格式化经度
-    if 'longitude' in gps_info:
+    if "longitude" in gps_info:
         lon_str = f"{gps_info['longitude']:.6f}°"
-        if 'longitude_ref' in gps_info:
+        if "longitude_ref" in gps_info:
             lon_str += f" {gps_info['longitude_ref']}"
         parts.append(f"经度: {lon_str}")
-    
+
     # 格式化高度
-    if 'altitude' in gps_info:
+    if "altitude" in gps_info:
         alt_str = f"{gps_info['altitude']:.1f}m"
-        if 'altitude_ref' in gps_info:
-            if gps_info['altitude_ref'] == 1:
+        if "altitude_ref" in gps_info:
+            if gps_info["altitude_ref"] == 1:
                 alt_str += " (海平面以下)"
             else:
                 alt_str += " (海平面以上)"
         parts.append(f"高度: {alt_str}")
-    
+
     # 格式化时间戳
-    if 'gps_timestamp' in gps_info and 'gps_datestamp' in gps_info:
-        timestamp = gps_info['gps_timestamp']
-        datestamp = gps_info['gps_datestamp']
+    if "gps_timestamp" in gps_info and "gps_datestamp" in gps_info:
+        timestamp = gps_info["gps_timestamp"]
+        datestamp = gps_info["gps_datestamp"]
         if isinstance(timestamp, tuple) and len(timestamp) == 3:
             time_str = f"{int(timestamp[0]):02d}:{int(timestamp[1]):02d}:{int(timestamp[2]):02d}"
             parts.append(f"GPS时间: {datestamp} {time_str}")
-    
+
     return "\n".join(parts) if parts else "GPS信息不完整"
+
+
+def compute_inclusion_relations(detections):
+    """计算组串与单组件的包含关系."""
+    strings = []
+    components = []
+    for idx, det in enumerate(detections):
+        if len(det) < 3:
+            continue
+        name = det[0]
+        bbox = det[2]
+        if name == "string":
+            strings.append((idx, bbox))
+        elif name == "component":
+            components.append((idx, bbox))
+
+    records = []
+    for s_idx, s_bbox in strings:
+        x1_s, y1_s, x2_s, y2_s = s_bbox
+        count = 0
+        for _, c_bbox in components:
+            x1_c, y1_c, x2_c, y2_c = c_bbox
+            if x1_c >= x1_s and y1_c >= y1_s and x2_c <= x2_s and y2_c <= y2_s:
+                count += 1
+        records.append([f"string_{s_idx}", count])
+
+    return pd.DataFrame(records, columns=["组串编号", "包含组件数"])

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,17 +1,17 @@
-import io
 import os
-from hashlib import md5
-from pathlib import Path
 
 import cv2
-import exifread
 import numpy as np
 import pandas as pd
-from matplotlib.colors import LinearSegmentedColormap
-from PIL import Image, ImageDraw, ImageFont
-from PIL.ExifTags import GPSTAGS, TAGS
+from PIL import ImageFont, ImageDraw, Image
+from PIL.ExifTags import TAGS, GPSTAGS
+import exifread
+from hashlib import md5
 from QtFusion.path import abs_path
+from matplotlib.colors import LinearSegmentedColormap
+from pathlib import Path
 from scipy.optimize import minimize
+import io
 
 
 class LocalFileObj(io.BytesIO):
@@ -19,7 +19,6 @@ class LocalFileObj(io.BytesIO):
         with open(file_path, "rb") as f:
             super().__init__(f.read())
         self.name = os.path.basename(file_path)
-
 
 def save_uploaded_file(uploaded_file):
     """
@@ -67,7 +66,7 @@ def concat_results(result, location, confidence, time):
         "识别结果": [result],
         "位置": [location],
         "置信度": [confidence],
-        "用时": [time],
+        "用时": [time]
     }
 
     results_df = pd.DataFrame(result_data)
@@ -177,15 +176,7 @@ def adjust_parameter(image_size, base_size=1000):
     return max_size / base_size
 
 
-def draw_detections(
-    image,
-    info,
-    color=(0, 0, 255),
-    alpha=0.2,
-    line_number=None,
-    is_api=False,
-    rectangle_bbox=False,
-):
+def draw_detections(image, info, color=(0, 0, 255), alpha=0.2, line_number=None, is_api=False, rectangle_bbox=False):
     """
     在图像上绘制检测结果，包括边界框、类别名称和掩码（如果有）
 
@@ -197,29 +188,15 @@ def draw_detections(
         line_number (int): 行号，用于在检测框中间绘制行号，默认为 None
         rectangle_bbox (bool): 是否绘制掩码的最小外接矩形，默认为 False
     """
-    name, bbox, conf, cls_id, mask = (
-        info["class_name"],
-        info["bbox"],
-        info["score"],
-        info["class_id"],
-        info["mask"],
-    )
+    name, bbox, conf, cls_id, mask = info['class_name'], info['bbox'], info['score'], info['class_id'], info['mask']
     adjust_param = adjust_parameter(image.shape[:2])
     spacing = int(20 * adjust_param)
 
     if mask is None:
         x1, y1, x2, y2 = bbox
         aim_frame_area = (x2 - x1) * (y2 - y1)
-        cv2.rectangle(
-            image, (x1, y1), (x2, y2), color=color, thickness=int(5 * adjust_param)
-        )
-        image = draw_with_chinese(
-            image,
-            name,
-            (x1, y1 - int(30 * adjust_param)),
-            font_size=int(35 * adjust_param),
-            color=color,
-        )
+        cv2.rectangle(image, (x1, y1), (x2, y2), color=color, thickness=int(5 * adjust_param))
+        image = draw_with_chinese(image, name, (x1, y1 - int(30 * adjust_param)), font_size=int(35 * adjust_param), color=color)
         y_offset = int(50 * adjust_param)  # 类别名称上方绘制，其下方留出空间
     else:
         mask_points = np.concatenate(mask)
@@ -229,49 +206,35 @@ def draw_detections(
             overlay = image.copy()
             cv2.fillPoly(overlay, [mask_points.astype(np.int32)], mask_color)
             image = cv2.addWeighted(overlay, 0.3, image, 0.7, 0)
-            cv2.drawContours(
-                image,
-                [mask_points.astype(np.int32)],
-                -1,
-                color=color,
-                thickness=int(8 * adjust_param),
-            )
+            cv2.drawContours(image, [mask_points.astype(np.int32)], -1, color=color, thickness=int(8 * adjust_param))
 
             # 绘制矩形包围框（如果启用）
             if rectangle_bbox:
                 x, y, w, h = cv2.boundingRect(mask_points.astype(np.int32))
                 cv2.rectangle(
-                    image,
-                    (x, y),
-                    (x + w, y + h),
-                    color=color,
-                    thickness=int(5 * adjust_param),
+                    image, 
+                    (x, y), 
+                    (x + w, y + h), 
+                    color=color, 
+                    thickness=int(5 * adjust_param)
                 )
 
             # 计算面积、周长、圆度
             area = cv2.contourArea(mask_points.astype(np.int32))
             perimeter = cv2.arcLength(mask_points.astype(np.int32), True)
-            circularity = 4 * np.pi * area / (perimeter**2) if perimeter > 0 else 0
+            circularity = 4 * np.pi * area / (perimeter ** 2) if perimeter > 0 else 0
 
             # 计算色彩
             mask = np.zeros(image.shape[:2], dtype=np.uint8)
             cv2.drawContours(mask, [mask_points.astype(np.int32)], -1, 255, -1)
             color_points = cv2.findNonZero(mask)
-            selected_points = color_points[
-                np.random.choice(color_points.shape[0], 5, replace=False)
-            ]
+            selected_points = color_points[np.random.choice(color_points.shape[0], 5, replace=False)]
             colors = np.mean([image[y, x] for x, y in selected_points[:, 0]], axis=0)
             color_str = f"({colors[0]:.1f}, {colors[1]:.1f}, {colors[2]:.1f})"
 
             # 绘制类别名称
             x, y = np.min(mask_points, axis=0).astype(int)
-            image = draw_with_chinese(
-                image,
-                name,
-                (x, y - int(30 * adjust_param)),
-                font_size=int(35 * adjust_param),
-                color=color,
-            )
+            image = draw_with_chinese(image, name, (x, y - int(30 * adjust_param)), font_size=int(35 * adjust_param), color=color)
             y_offset = int(50 * adjust_param)  # 类别名称上方绘制，其下方留出空间
 
             # 绘制面积、周长、圆度和色彩值
@@ -289,13 +252,7 @@ def draw_detections(
         x1, y1, x2, y2 = bbox
         center_x = int((x1 + x2) / 2)
         center_y = int((y1 + y2) / 2)
-        image = draw_with_chinese(
-            image,
-            str(line_number),
-            (center_x, center_y),
-            font_size=int(20 * adjust_param),
-            color=color,
-        )
+        image = draw_with_chinese(image, str(line_number), (center_x, center_y), font_size=int(20 * adjust_param), color=color)
 
     return image, aim_frame_area
 
@@ -370,17 +327,12 @@ def convert_to_pseudo_colorizer(image, contrast=1.0, brightness=0):
         (0.0, (128, 128, 128)),  # 最低温度：黑色
         (0.3, (128, 0, 128)),  # 低温温度：紫色
         (0.8, (255, 50, 0)),  # 高温区域：红色
-        (1.0, (255, 255, 0)),  # 最高温度：黄色
+        (1.0, (255, 255, 0))  # 最高温度：黄色
     ]
 
     # 创建自定义颜色映射
-    colors = sorted(
-        [(pos, tuple(np.array(color) / 255)) for pos, color in colors],
-        key=lambda x: x[0],
-    )
-    colormap = LinearSegmentedColormap.from_list(
-        "custom", [(pos, color) for pos, color in colors]
-    )
+    colors = sorted([(pos, tuple(np.array(color) / 255)) for pos, color in colors], key=lambda x: x[0])
+    colormap = LinearSegmentedColormap.from_list("custom", [(pos, color) for pos, color in colors])
 
     # 将图像转换为灰度图像
     image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
@@ -389,9 +341,7 @@ def convert_to_pseudo_colorizer(image, contrast=1.0, brightness=0):
     img_array = np.array(image)
 
     # 应用对比度和亮度调整
-    img_array = np.clip(
-        img_array.astype(np.float32) * contrast + brightness, 0, 255
-    ).astype(np.uint8)
+    img_array = np.clip(img_array.astype(np.float32) * contrast + brightness, 0, 255).astype(np.uint8)
 
     # 应用颜色映射
     colored_array = colormap(img_array / 255.0)[:, :, :3]  # 忽略alpha通道
@@ -415,9 +365,7 @@ def is_black_and_white(image_array):
         return
 
     # 检查每个像素的 B、G、R 通道值是否相等
-    is_bw = np.all(image_array[:, :, 0] == image_array[:, :, 1]) and np.all(
-        image_array[:, :, 1] == image_array[:, :, 2]
-    )
+    is_bw = np.all(image_array[:, :, 0] == image_array[:, :, 1]) and np.all(image_array[:, :, 1] == image_array[:, :, 2])
 
     return is_bw
 
@@ -440,12 +388,10 @@ def camera_undistortion(frame, camera_matrix=None, dist_coeffs=None):
             new_camera_mtx, roi = cv2.getOptimalNewCameraMatrix(
                 camera_matrix, dist_coeffs, (w, h), 1, (w, h)
             )
-            undistorted = cv2.undistort(
-                frame, camera_matrix, dist_coeffs, None, new_camera_mtx
-            )
+            undistorted = cv2.undistort(frame, camera_matrix, dist_coeffs, None, new_camera_mtx)
             # 可选：裁剪ROI
             x, y, w, h = roi
-            undistorted = undistorted[y : y + h, x : x + w]
+            undistorted = undistorted[y:y+h, x:x+w]
             return undistorted
         except Exception as e:
             print(f"去畸变失败: {e}")
@@ -499,21 +445,19 @@ def rotate_image(img, angle_x, angle_y, zoom_factor=1.0):
 
     # 构造 K
     f = 1.2 * max(h, w)
-    K = np.array([[f, 0, cx], [0, f, cy], [0, 0, 1]])
+    K = np.array([[f, 0, cx],
+                  [0, f, cy],
+                  [0, 0, 1]])
     K_inv = np.linalg.inv(K)
 
     # 构造 R
-    Rx = np.array(
-        [
-            [1, 0, 0],
-            [0, np.cos(pitch), -np.sin(pitch)],
-            [0, np.sin(pitch), np.cos(pitch)],
-        ]
-    )
-
-    Rz = np.array(
-        [[np.cos(roll), -np.sin(roll), 0], [np.sin(roll), np.cos(roll), 0], [0, 0, 1]]
-    )
+    Rx = np.array([[1, 0, 0],
+                   [0, np.cos(pitch), -np.sin(pitch)],
+                   [0, np.sin(pitch),  np.cos(pitch)]])
+    
+    Rz = np.array([[np.cos(roll), -np.sin(roll), 0],
+                   [np.sin(roll),  np.cos(roll), 0],
+                   [0, 0, 1]])
     R = Rz @ Rx
 
     # 透视矩阵 H
@@ -529,7 +473,9 @@ def rotate_image(img, angle_x, angle_y, zoom_factor=1.0):
     dy = cy - new_center[1, 0]
 
     # 构造平移矩阵 T
-    T = np.array([[1, 0, dx], [0, 1, dy], [0, 0, 1]])
+    T = np.array([[1, 0, dx],
+                  [0, 1, dy],
+                  [0, 0, 1]])
 
     # 加入平移补偿后的新变换矩阵
     H_corrected = T @ H
@@ -547,9 +493,7 @@ def rotate_image(img, angle_x, angle_y, zoom_factor=1.0):
         new_w, new_h = int(w * zoom_factor), int(h * zoom_factor)
         result = cv2.resize(result, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
         pad_w, pad_h = (w - new_w) // 2, (h - new_h) // 2
-        result = cv2.copyMakeBorder(
-            result, pad_h, pad_h, pad_w, pad_w, cv2.BORDER_CONSTANT, value=[0, 0, 0]
-        )
+        result = cv2.copyMakeBorder(result, pad_h, pad_h, pad_w, pad_w, cv2.BORDER_CONSTANT, value=[0, 0, 0])
 
     return result
 
@@ -561,10 +505,10 @@ def order_points(pts):
     rect = np.zeros((4, 2), dtype="float32")
     s = pts.sum(axis=1)
     diff = np.diff(pts, axis=1)
-    rect[0] = pts[np.argmin(s)]  # top-left
-    rect[2] = pts[np.argmax(s)]  # bottom-right
-    rect[1] = pts[np.argmin(diff)]  # top-right
-    rect[3] = pts[np.argmax(diff)]  # bottom-left
+    rect[0] = pts[np.argmin(s)]      # top-left
+    rect[2] = pts[np.argmax(s)]      # bottom-right
+    rect[1] = pts[np.argmin(diff)]   # top-right
+    rect[3] = pts[np.argmax(diff)]   # bottom-left
     return rect
 
 
@@ -594,7 +538,6 @@ def find_largest_valid_contour(image, scale_factor=0.1):
         return None
     largest_cnt = max(valid_cnts, key=cv2.contourArea)
     return largest_cnt
-
 
 def auto_keystone_correction(image, scale_factor=0.1, output_path=None):
     """
@@ -633,10 +576,12 @@ def auto_keystone_correction(image, scale_factor=0.1, output_path=None):
     maxWidth = int(max(widthA, widthB))
     maxHeight = int(max(heightA, heightB))
 
-    dst_pts = np.array(
-        [[0, 0], [maxWidth - 1, 0], [maxWidth - 1, maxHeight - 1], [0, maxHeight - 1]],
-        dtype="float32",
-    )
+    dst_pts = np.array([
+        [0, 0],
+        [maxWidth - 1, 0],
+        [maxWidth - 1, maxHeight - 1],
+        [0, maxHeight - 1]
+    ], dtype="float32")
 
     # 透视变换
     M = cv2.getPerspectiveTransform(box, dst_pts)
@@ -694,23 +639,20 @@ def enhance_texture(image, method="clahe"):
         # Apply Histogram Equalization
         enhanced_gray = cv2.equalizeHist(gray)
     else:
-        raise ValueError(
-            "Invalid enhancement method. Choose 'CLAHE' or 'Histogram Equalization'."
-        )
+        raise ValueError("Invalid enhancement method. Choose 'CLAHE' or 'Histogram Equalization'.")
 
     # Convert the enhanced grayscale image back to RGB format
     enhanced_rgb = cv2.cvtColor(enhanced_gray, cv2.COLOR_GRAY2BGR)
 
     return enhanced_rgb
 
-
 def extract_gps_info(image_path):
     """
     从图片EXIF信息中提取GPS经纬度信息
-
+    
     Args:
         image_path (str): 图片文件路径
-
+        
     Returns:
         dict: 包含GPS信息的字典，包括经度、纬度、高度等
     """
@@ -779,63 +721,62 @@ def extract_gps_info(image_path):
         print(f"提取GPS信息时出错: {e}")
         return None
 
-
 def format_gps_info(gps_info):
     """
     格式化GPS信息为可读的字符串
-
+    
     Args:
         gps_info (dict): GPS信息字典
-
+        
     Returns:
         str: 格式化后的GPS信息字符串
     """
     if not gps_info:
         return "未找到GPS信息"
-
+    
     parts = []
-
+    
     # 格式化纬度
-    if "latitude" in gps_info:
+    if 'latitude' in gps_info:
         lat_str = f"{gps_info['latitude']:.6f}°"
-        if "latitude_ref" in gps_info:
+        if 'latitude_ref' in gps_info:
             lat_str += f" {gps_info['latitude_ref']}"
         parts.append(f"纬度: {lat_str}")
-
+    
     # 格式化经度
-    if "longitude" in gps_info:
+    if 'longitude' in gps_info:
         lon_str = f"{gps_info['longitude']:.6f}°"
-        if "longitude_ref" in gps_info:
+        if 'longitude_ref' in gps_info:
             lon_str += f" {gps_info['longitude_ref']}"
         parts.append(f"经度: {lon_str}")
-
+    
     # 格式化高度
-    if "altitude" in gps_info:
+    if 'altitude' in gps_info:
         alt_str = f"{gps_info['altitude']:.1f}m"
-        if "altitude_ref" in gps_info:
-            if gps_info["altitude_ref"] == 1:
+        if 'altitude_ref' in gps_info:
+            if gps_info['altitude_ref'] == 1:
                 alt_str += " (海平面以下)"
             else:
                 alt_str += " (海平面以上)"
         parts.append(f"高度: {alt_str}")
-
+    
     # 格式化时间戳
-    if "gps_timestamp" in gps_info and "gps_datestamp" in gps_info:
-        timestamp = gps_info["gps_timestamp"]
-        datestamp = gps_info["gps_datestamp"]
+    if 'gps_timestamp' in gps_info and 'gps_datestamp' in gps_info:
+        timestamp = gps_info['gps_timestamp']
+        datestamp = gps_info['gps_datestamp']
         if isinstance(timestamp, tuple) and len(timestamp) == 3:
             time_str = f"{int(timestamp[0]):02d}:{int(timestamp[1]):02d}:{int(timestamp[2]):02d}"
             parts.append(f"GPS时间: {datestamp} {time_str}")
-
+    
     return "\n".join(parts) if parts else "GPS信息不完整"
 
 
 def compute_inclusion_relations(detections):
-    """计算组串与单组件的包含关系."""
+    """统计每个string对象包含的component数量."""
     strings = []
     components = []
     for idx, det in enumerate(detections):
-        if len(det) < 3:
+        if not isinstance(det, list) or len(det) < 3:
             continue
         name = det[0]
         bbox = det[2]

--- a/src/web.py
+++ b/src/web.py
@@ -1,62 +1,135 @@
-import base64
-import hashlib
-import json
-import os
 import random
 import tempfile
-import threading
 import time
-import tkinter as tk
-from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
-from functools import lru_cache
-from tkinter import filedialog
-
+import os
 import cv2
+import json
 import numpy as np
 import pandas as pd
 import streamlit as st
 from QtFusion.path import abs_path
 from QtFusion.utils import drawRectBox
-
-from auth import get_access_token, verify_token
-from chinese_name_list import (EL_class_colors, EL_type, Other_class_colors,
-                               Other_type, Segmentation_class_colors,
-                               Segmentation_type, Thermo_class_colors,
-                               Thermo_type, Visible_class_colors, Visible_type)
-from image_optimizer import (get_image_optimizer, optimize_image_display,
-                             process_uploaded_images)
-from log import LogTable, ResultLogger
+from log import ResultLogger, LogTable
 from model import Web_Detector
-# 📝 命名配置模块导入
-from naming_config import (  # 系统配置; 侧边栏配置; 主界面配置; 按钮配置; 消息配置; 显示配置; 数据映射; 工具函数; UI 获取函数; 兼容性支持
-    BUTTON_TEXTS, CAMERA_MESSAGES, DETECTION_MESSAGES, EXPORT_FORMAT_MAP,
-    EXPORT_MESSAGES, FILE_MESSAGES, GENERAL_MESSAGES, IMAGE_DISPLAY_LABELS,
-    IMAGE_TYPE_MAP, MAIN_HEADERS, MAIN_LABELS, MAIN_OPTIONS, METRICS_LABELS,
-    MODEL_MESSAGES, RTSP_MESSAGES, SIDEBAR_HEADERS, SIDEBAR_HINTS,
-    SIDEBAR_LABELS, SIDEBAR_OPTIONS, STATISTICS_LABELS, STATUS_MESSAGES,
-    SYSTEM_DEFAULTS, SYSTEM_INFO, TASK_TYPE_MAP, UI_LABELS, UI_OPTIONS,
-    VIDEO_MESSAGES, WARNING_MESSAGES, generate_filename, get_button_text,
-    get_camera_message, get_detection_message, get_export_message,
-    get_file_message, get_general_message, get_image_display_label,
-    get_main_header, get_main_label, get_main_option, get_metric_label,
-    get_model_message, get_rtsp_message, get_sidebar_header, get_sidebar_hint,
-    get_sidebar_label, get_sidebar_option, get_statistic_label,
-    get_statistic_message, get_status_message, get_video_message,
-    get_warning_message)
-# 🚀 性能优化模块导入
-from streamlit_config import (add_performance_css,
-                              optimize_streamlit_performance,
-                              setup_image_optimization)
+from chinese_name_list import (
+    EL_type,
+    EL_class_colors,
+    Thermo_type,
+    Other_type,
+    Thermo_class_colors,
+    Visible_type,
+    Visible_class_colors,
+    Segmentation_type,
+    Segmentation_class_colors,
+    Other_class_colors,
+)
 from ui_style import def_css_html
-from utils import (LocalFileObj, auto_keystone_correction,
-                   auto_undistort_image, camera_undistortion,
-                   compute_inclusion_relations, concat_results,
-                   convert_to_pseudo_colorizer, draw_detections,
-                   enhance_texture, extract_gps_info,
-                   fill_largest_polygon_white, format_time, get_camera_names,
-                   is_black_and_white, load_default_image, rotate_image,
-                   save_chinese_image, save_uploaded_file)
+from utils import (
+    is_black_and_white,
+    save_uploaded_file,
+    concat_results,
+    load_default_image,
+    get_camera_names,
+    draw_detections,
+    save_chinese_image,
+    format_time,
+    convert_to_pseudo_colorizer,
+    camera_undistortion,
+    auto_undistort_image,
+    rotate_image,
+    auto_keystone_correction,
+    enhance_texture,
+    fill_largest_polygon_white,
+    extract_gps_info,
+    compute_inclusion_relations,
+)
+from datetime import datetime
+from auth import verify_token, get_access_token
+import tkinter as tk
+from tkinter import filedialog
+from utils import LocalFileObj
+import base64
+import hashlib
+from functools import lru_cache
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+# 🚀 性能优化模块导入
+from streamlit_config import (
+    optimize_streamlit_performance,
+    setup_image_optimization,
+    add_performance_css,
+)
+
+# 📝 命名配置模块导入
+from naming_config import (
+    # 系统配置
+    SYSTEM_INFO,
+    SYSTEM_DEFAULTS,
+    # 侧边栏配置
+    SIDEBAR_HEADERS,
+    SIDEBAR_LABELS,
+    SIDEBAR_OPTIONS,
+    SIDEBAR_HINTS,
+    # 主界面配置
+    MAIN_HEADERS,
+    MAIN_LABELS,
+    MAIN_OPTIONS,
+    # 按钮配置
+    BUTTON_TEXTS,
+    # 消息配置
+    DETECTION_MESSAGES,
+    FILE_MESSAGES,
+    VIDEO_MESSAGES,
+    CAMERA_MESSAGES,
+    RTSP_MESSAGES,
+    MODEL_MESSAGES,
+    WARNING_MESSAGES,
+    GENERAL_MESSAGES,
+    EXPORT_MESSAGES,
+    # 显示配置
+    IMAGE_DISPLAY_LABELS,
+    STATISTICS_LABELS,
+    METRICS_LABELS,
+    # 数据映射
+    IMAGE_TYPE_MAP,
+    TASK_TYPE_MAP,
+    EXPORT_FORMAT_MAP,
+    # 工具函数
+    get_detection_message,
+    get_file_message,
+    get_video_message,
+    get_camera_message,
+    get_rtsp_message,
+    get_model_message,
+    get_warning_message,
+    get_general_message,
+    get_export_message,
+    get_statistic_message,
+    get_metric_label,
+    generate_filename,
+    # UI 获取函数
+    get_sidebar_header,
+    get_sidebar_label,
+    get_sidebar_option,
+    get_sidebar_hint,
+    get_main_header,
+    get_main_label,
+    get_main_option,
+    get_button_text,
+    get_image_display_label,
+    get_statistic_label,
+    # 兼容性支持
+    STATUS_MESSAGES,
+    UI_LABELS,
+    UI_OPTIONS,
+    get_status_message,
+)
+from image_optimizer import (
+    get_image_optimizer,
+    optimize_image_display,
+    process_uploaded_images,
+)
 
 
 # 🚀 性能优化：添加缓存装饰器
@@ -281,9 +354,7 @@ class Detection_UI:
         self.gps_lon_placeholder = None
         self.gps_alt_placeholder = None
         self.gps_time_placeholder = None
-        # 包含关系表格占位符
         self.inclusion_table_placeholder = None
-        # 是否显示包含关系
         self.show_inclusion = False
 
         self.new_width = 1080
@@ -685,11 +756,10 @@ class Detection_UI:
         self.enable_gps_parsing = st.sidebar.checkbox(
             get_sidebar_label("enable_gps_parsing"),
             value=True,
-            help="勾选时，将解析图片的RTK GPS信息并在主页面显示",
+            help="勾选时，将解析图片的RTK GPS信息并在主页面显示"
         )
         st.sidebar.caption(get_sidebar_hint("gps_parsing_hint"))
 
-        # 是否显示分割包含关系
         self.show_inclusion = st.sidebar.checkbox(
             get_sidebar_label("show_inclusion_relationship"),
             value=False,
@@ -817,9 +887,9 @@ class Detection_UI:
             self.detect_class_color = Segmentation_class_colors
 
         # 提示用户选择的图像类型
-        st.sidebar.caption(
-            get_sidebar_hint("image_type_hint").format(type=self.image_type)
-        )
+        st.sidebar.caption(get_sidebar_hint("image_type_hint").format(
+            type=self.image_type
+        ))
 
         # 设置侧边栏的选择需要检测的目标类别部分，默认选择所有类别
         st.sidebar.header(get_sidebar_header("target_class_selection"))
@@ -1194,7 +1264,9 @@ class Detection_UI:
                 # 转为文件对象
                 self.uploaded_video = [LocalFileObj(f) for f in video_files]
             else:
-                st.sidebar.caption(get_sidebar_hint("video_folder_selection_hint"))
+                st.sidebar.caption(
+                    get_sidebar_hint("video_folder_selection_hint")
+                )
                 self.uploaded_video = []
 
         # 清空按钮
@@ -1347,9 +1419,7 @@ class Detection_UI:
                     self.calibration_file = calibration_file.name
                     st.sidebar.success(get_camera_message("camera_calibration_success"))
                 except Exception as e:
-                    st.sidebar.error(
-                        get_camera_message("camera_calibration_failed", error=e)
-                    )
+                    st.sidebar.error(get_camera_message("camera_calibration_failed", error=e))
             elif calibration_input.strip():
                 try:
                     # 尝试先用json解析，否则用eval（仅限受信环境）
@@ -1359,18 +1429,14 @@ class Detection_UI:
                         calib_data = eval(calibration_input, {"__builtins__": {}})
                     self.calibration_file = "sidebar_input"
                 except Exception as e:
-                    st.sidebar.error(
-                        get_camera_message("camera_calibration_failed", error=e)
-                    )
+                    st.sidebar.error(get_camera_message("camera_calibration_failed", error=e))
             if calib_data is not None:
                 try:
                     self.camera_matrix = np.array(calib_data["camera_matrix"])
                     self.dist_coeffs = np.array(calib_data["dist_coeffs"])
                     st.sidebar.success(get_camera_message("camera_calibration_success"))
                 except Exception as e:
-                    st.sidebar.error(
-                        get_camera_message("camera_calibration_failed", error=e)
-                    )
+                    st.sidebar.error(get_camera_message("camera_calibration_failed", error=e))
                     self.camera_matrix = None
                     self.dist_coeffs = None
                     self.calibration_file = None
@@ -1552,9 +1618,7 @@ class Detection_UI:
 
                 except Exception as e:
                     st.sidebar.error(
-                        get_file_message(
-                            "image_processing_error", filename=file_name, error=str(e)
-                        )
+                        get_file_message("image_processing_error", filename=file_name, error=str(e))
                     )
 
             else:  # Handle single file upload
@@ -1997,7 +2061,9 @@ class Detection_UI:
             return
 
         # 获取当前选中的目标过滤选项（多选）
-        selected_targets = st.session_state.get("multiselect_target", [])
+        selected_targets = st.session_state.get(
+            "multiselect_target", []
+        )
 
         # 获取原始帧
         frame = saved_images_ini[frame_id]  # 获取指定帧的初始图像
@@ -2021,8 +2087,7 @@ class Detection_UI:
                         # 如果选择了目标过滤，跳过不匹配的目标
                         if (
                             selected_targets  # 如果有选中的目标
-                            and chinese_name
-                            not in selected_targets  # 且当前目标不在选中列表中
+                            and chinese_name not in selected_targets  # 且当前目标不在选中列表中
                         ):
                             continue
 
@@ -2061,20 +2126,14 @@ class Detection_UI:
 
         # 调整图像大小
         if hasattr(self, "optimized_image_resize"):
-            resized_image = self.optimized_image_resize(
-                image, self.display_width, self.display_height
-            )
-            resized_frame = self.optimized_image_resize(
-                frame, self.display_width, self.display_height
-            )
+            resized_image = self.optimized_image_resize(image, self.display_width, self.display_height)
+            resized_frame = self.optimized_image_resize(frame, self.display_width, self.display_height)
         else:
             resized_image = cv2.resize(image, (self.display_width, self.display_height))
             resized_frame = cv2.resize(frame, (self.display_width, self.display_height))
 
         # 更新表格数据
-        detection_results = (
-            saved_results[frame_id] if frame_id < len(saved_results) else []
-        )
+        detection_results = (saved_results[frame_id] if frame_id < len(saved_results) else [])
 
         if detection_results:
             # 使用列表推导式提高性能
@@ -2099,7 +2158,7 @@ class Detection_UI:
                 self.table_placeholder.table(disp_res.results_df)
                 self.update_category_counts(frame_id)
                 if (
-                    getattr(self, "show_inclusion", False)
+                    self.show_inclusion
                     and self.model_type == SYSTEM_DEFAULTS["model_type_segmentation"]
                 ):
                     inclusion_df = compute_inclusion_relations(filtered_results)
@@ -2139,6 +2198,8 @@ class Detection_UI:
                     )
                 )
             self.update_category_counts(frame_id)
+            if hasattr(self, "inclusion_table_placeholder"):
+                self.inclusion_table_placeholder.empty()
 
         # 获取图像名称
         img_name = (
@@ -2187,15 +2248,15 @@ class Detection_UI:
                         if gps:
                             if "latitude" in gps:
                                 lat = f"{gps['latitude']:.6f}°"
-                                if "latitude_ref" in gps:
+                                if 'latitude_ref' in gps:
                                     lat += f" {gps['latitude_ref']}"
                             if "longitude" in gps:
                                 lon = f"{gps['longitude']:.6f}°"
-                                if "longitude_ref" in gps:
+                                if 'longitude_ref' in gps:
                                     lon += f" {gps['longitude_ref']}"
                             if "altitude" in gps:
                                 alt = f"{gps['altitude']:.1f}m"
-                                if gps.get("altitude_ref") == 1:
+                                if gps.get('altitude_ref') == 1:
                                     alt += " (海平面以下)"
                                 else:
                                     alt += " (海平面以上)"
@@ -2389,9 +2450,7 @@ class Detection_UI:
         detection_time = "0.00s"
 
         # 使用 display_detection_results 函数显示结果
-        res = concat_results(
-            detection_result, detection_location, detection_confidence, detection_time
-        )
+        res = concat_results(detection_result, detection_location, detection_confidence, detection_time)
         self.table_placeholder.table(res)
         # 注意：这里是演示模式，不需要更新类别统计
         # 添加适当的延迟
@@ -2400,21 +2459,15 @@ class Detection_UI:
     def update_category_counts(self, current_frame_id=None):
         """更新并显示类别计数表格"""
         # 🔧 修复：添加安全检查，确保占位符存在
-        if (
-            not hasattr(self, "current_image_category_placeholder")
-            or self.current_image_category_placeholder is None
-        ):
+        if not hasattr(self, "current_image_category_placeholder") or self.current_image_category_placeholder is None:
             return
-        if (
-            not hasattr(self, "total_category_placeholder")
-            or self.total_category_placeholder is None
-        ):
+        if not hasattr(self, "total_category_placeholder") or self.total_category_placeholder is None:
             return
 
         # 获取当前图片的类别统计
         if current_frame_id is not None:
             self.update_current_image_category_counts(current_frame_id)
-
+        
         # 获取总体类别统计
         self.update_total_category_counts()
 
@@ -2424,24 +2477,20 @@ class Detection_UI:
             # 获取当前图片的检测结果
             saved_results = getattr(self.logTable, "saved_results", [])
             saved_names = st.session_state.get("saved_names", [])
-
+            
             if frame_id >= len(saved_results) or not saved_results[frame_id]:
                 # 如果没有检测结果，显示空表格
                 empty_df = pd.DataFrame(columns=["类别", "数量"])
                 self.current_image_category_placeholder.table(empty_df)
                 return
-
+            
             # 获取当前图片名称
-            img_name = (
-                saved_names[frame_id]
-                if frame_id < len(saved_names)
-                else f"图片_{frame_id+1}"
-            )
-
+            img_name = saved_names[frame_id] if frame_id < len(saved_names) else f"图片_{frame_id+1}"
+            
             # 统计当前图片的类别
             current_results = saved_results[frame_id]
             category_counts = {}
-
+            
             for detInfo in current_results:
                 if isinstance(detInfo, list) and len(detInfo) >= 2:
                     category = detInfo[1]  # 类别名称在索引1
@@ -2449,58 +2498,44 @@ class Detection_UI:
                         category_counts[category] += 1
                     else:
                         category_counts[category] = 1
-
+            
             # 转换为DataFrame
             if category_counts:
-                current_counts = pd.DataFrame(
-                    list(category_counts.items()), columns=["类别", "数量"]
-                )
+                current_counts = pd.DataFrame(list(category_counts.items()), columns=["类别", "数量"])
                 current_counts = current_counts.sort_values("数量", ascending=False)
             else:
                 current_counts = pd.DataFrame(columns=["类别", "数量"])
-
+            
             # 添加表格标题信息
             if not current_counts.empty:
-                self.current_image_category_placeholder.write(
-                    f"📊 **{img_name}** 中检测到的目标:"
-                )
+                self.current_image_category_placeholder.write(f"📊 **{img_name}** 中检测到的目标:")
                 self.current_image_category_placeholder.table(current_counts)
             else:
-                self.current_image_category_placeholder.write(
-                    f"📊 **{img_name}** 中未检测到目标"
-                )
-                self.current_image_category_placeholder.table(
-                    pd.DataFrame(columns=["类别", "数量"])
-                )
-
+                self.current_image_category_placeholder.write(f"📊 **{img_name}** 中未检测到目标")
+                self.current_image_category_placeholder.table(pd.DataFrame(columns=["类别", "数量"]))
+                
         except Exception as e:
             st.error(f"更新当前图片类别统计时出错: {str(e)}")
-            self.current_image_category_placeholder.table(
-                pd.DataFrame(columns=["类别", "数量"])
-            )
+            self.current_image_category_placeholder.table(pd.DataFrame(columns=["类别", "数量"]))
 
     def update_total_category_counts(self):
         """更新总体类别统计，包含图片来源信息"""
         try:
             saved_results = getattr(self.logTable, "saved_results", [])
             saved_names = st.session_state.get("saved_names", [])
-
+            
             if not saved_results:
                 # 如果没有检测结果，显示空表格
                 empty_df = pd.DataFrame(columns=["类别", "总数量", "分布图片"])
                 self.total_category_placeholder.table(empty_df)
                 return
-
+            
             # 统计每个类别在各图片中的分布
             category_distribution = {}
-
+            
             for frame_id, results in enumerate(saved_results):
-                img_name = (
-                    saved_names[frame_id]
-                    if frame_id < len(saved_names)
-                    else f"图片_{frame_id+1}"
-                )
-
+                img_name = saved_names[frame_id] if frame_id < len(saved_names) else f"图片_{frame_id+1}"
+                
                 if results:
                     frame_categories = {}
                     for detInfo in results:
@@ -2510,43 +2545,33 @@ class Detection_UI:
                                 frame_categories[category] += 1
                             else:
                                 frame_categories[category] = 1
-
+                    
                     # 记录每个类别在当前图片中的分布
                     for category, count in frame_categories.items():
                         if category not in category_distribution:
                             category_distribution[category] = []
                         category_distribution[category].append(f"{img_name}({count})")
-
+            
             # 转换为DataFrame
             if category_distribution:
                 total_data = []
                 for category, distribution in category_distribution.items():
-                    total_count = sum(
-                        int(item.split("(")[1].split(")")[0]) for item in distribution
-                    )
+                    total_count = sum(int(item.split('(')[1].split(')')[0]) for item in distribution)
                     distribution_str = ", ".join(distribution)
                     total_data.append([category, total_count, distribution_str])
-
-                total_counts = pd.DataFrame(
-                    total_data, columns=["类别", "总数量", "分布图片"]
-                )
+                
+                total_counts = pd.DataFrame(total_data, columns=["类别", "总数量", "分布图片"])
                 total_counts = total_counts.sort_values("总数量", ascending=False)
-
-                self.total_category_placeholder.write(
-                    f"📈 **总体统计** (共{len(saved_results)}张图片):"
-                )
+                
+                self.total_category_placeholder.write(f"📈 **总体统计** (共{len(saved_results)}张图片):")
                 self.total_category_placeholder.table(total_counts)
             else:
                 self.total_category_placeholder.write("📈 **总体统计**: 暂无检测结果")
-                self.total_category_placeholder.table(
-                    pd.DataFrame(columns=["类别", "总数量", "分布图片"])
-                )
-
+                self.total_category_placeholder.table(pd.DataFrame(columns=["类别", "总数量", "分布图片"]))
+                
         except Exception as e:
             st.error(f"更新总体类别统计时出错: {str(e)}")
-            self.total_category_placeholder.table(
-                pd.DataFrame(columns=["类别", "总数量", "分布图片"])
-            )
+            self.total_category_placeholder.table(pd.DataFrame(columns=["类别", "总数量", "分布图片"]))
 
     def setupMainWindow(self):
         """
@@ -2626,7 +2651,7 @@ class Detection_UI:
             st.subheader(get_main_header("current_image_results"))
             self.table_placeholder = st.empty()  # 调整到最右侧显示
             self.table_placeholder.table(res)
-
+            
             # 在当前图片检测结果下方添加当前图片类别统计
             st.subheader(get_main_header("current_category_statistics"))
             self.current_image_category_placeholder = st.empty()
@@ -2654,23 +2679,15 @@ class Detection_UI:
                 detected_targets = st.session_state.get("select_info", ["全部目标"])
 
             # 从检测目标列表中移除"全部目标"，只保留实际的类别名称
-            available_targets = [
-                target for target in detected_targets if target != "全部目标"
-            ]
+            available_targets = [target for target in detected_targets if target != "全部目标"]
 
             # multiselect动态key，确保当目标列表变化时multiselect会刷新
-            multiselect_key = (
-                f"multiselect_target_{idx}_{hash(tuple(available_targets))}"
-            )
+            multiselect_key = f"multiselect_target_{idx}_{hash(tuple(available_targets))}"
 
             # 确保当前选中的目标在新的目标列表中，默认选择所有可用目标
-            current_selected = st.session_state.get(
-                "multiselect_target", available_targets.copy()
-            )
+            current_selected = st.session_state.get("multiselect_target", available_targets.copy())
             # 过滤掉不在当前目标列表中的选项
-            current_selected = [
-                target for target in current_selected if target in available_targets
-            ]
+            current_selected = [target for target in current_selected if target in available_targets]
             # 如果没有选中任何目标，默认选择所有目标
             if not current_selected:
                 current_selected = available_targets.copy()
@@ -2680,9 +2697,7 @@ class Detection_UI:
                 col_select_all, col_select_none = st.columns(2)
                 with col_select_all:
                     if st.button("全选", key=f"select_all_{idx}"):
-                        st.session_state["multiselect_target"] = (
-                            available_targets.copy()
-                        )
+                        st.session_state["multiselect_target"] = available_targets.copy()
                         st.rerun()
                 with col_select_none:
                     if st.button("全不选", key=f"select_none_{idx}"):
@@ -2705,14 +2720,14 @@ class Detection_UI:
                 st.session_state["multiselect_target"] = selected_targets
                 st.session_state["last_selected_targets"] = selected_targets
                 self.toggle_comboBox(idx)
-
+            
         # 图片浏览控制（移动到总体类别统计上方）
         st.markdown("---")
-
+        
         # 显示批量处理汇总信息（如果存在）
         if st.session_state.get("batch_processing_summary"):
             st.success(st.session_state["batch_processing_summary"])
-
+        
         st.subheader(get_main_header("image_browser_control"))
 
         # 检查是否有检测结果（优先检查session state，然后检查logTable）
@@ -2721,9 +2736,7 @@ class Detection_UI:
             saved_images_ini = self.logTable.saved_images_ini
             # 同步到session state
             st.session_state["saved_images_ini"] = saved_images_ini
-            st.session_state["saved_images"] = getattr(
-                self.logTable, "saved_images", []
-            )
+            st.session_state["saved_images"] = getattr(self.logTable, "saved_images", [])
             st.session_state["saved_names"] = getattr(self.logTable, "saved_names", [])
 
         if len(saved_images_ini) > 0:
@@ -2751,17 +2764,11 @@ class Detection_UI:
                     st.rerun()
 
             with col_info:
-                st.write(
-                    get_statistic_message(
-                        "image_index_info", current=current_index + 1, total=total_imgs
-                    )
-                )
+                st.write(get_statistic_message("image_index_info", current=current_index + 1, total=total_imgs))
                 # 显示当前图片名称
                 if current_index < len(st.session_state.get("saved_names", [])):
                     img_name = st.session_state["saved_names"][current_index]
-                    st.caption(
-                        get_statistic_message("filename_info", filename=img_name)
-                    )
+                    st.caption(get_statistic_message("filename_info", filename=img_name))
 
             with col_next:
                 if st.button(
@@ -2769,9 +2776,7 @@ class Detection_UI:
                     key="next_btn",
                     disabled=(current_index >= total_imgs - 1),
                 ):
-                    st.session_state["image_play_index"] = min(
-                        total_imgs - 1, current_index + 1
-                    )
+                    st.session_state["image_play_index"] = min(total_imgs - 1, current_index + 1)
                     st.rerun()
 
             # 添加滑块控制
@@ -2792,24 +2797,18 @@ class Detection_UI:
             st.info(get_detection_message("no_detection_results"))
             # 显示默认图像
             if hasattr(self, "image_placeholder"):
-                self.image_placeholder.image(
-                    load_default_image(),
-                    caption=get_image_display_label("original_view"),
-                )
+                self.image_placeholder.image(load_default_image(), caption=get_image_display_label("original_view"))
                 if self.display_mode == "对比显示" and hasattr(
                     self, "image_placeholder_res"
                 ):
-                    self.image_placeholder_res.image(
-                        load_default_image(),
-                        caption=get_image_display_label("detection_view"),
-                    )
+                    self.image_placeholder_res.image(load_default_image(), caption=get_image_display_label("detection_view"))
 
         # 🔧 修复：在创建占位符后再调用update_category_counts
         st.subheader(get_main_header("total_category_statistics"))
-
+        
         # 总体类别统计
         self.total_category_placeholder = st.empty()
-
+        
         # 初始化类别统计（使用当前图片索引）
         current_idx = st.session_state.get("image_play_index", 0)
         self.update_category_counts(current_idx)
@@ -2889,9 +2888,7 @@ class Detection_UI:
 
         with col1:
             st.write("")
-            run_button = st.button(
-                get_button_text("start_detection"), key="main_start_detection"
-            )
+            run_button = st.button(get_button_text("start_detection"), key="main_start_detection")
             self.close_placeholder = st.empty()
 
         st.subheader(get_main_header("realtime_dashboard"))
@@ -2984,11 +2981,7 @@ class Detection_UI:
                     st.warning(get_rtsp_message("input_rtsp_first"))
 
             else:
-                st.error(
-                    get_warning_message(
-                        "unsupported_input_source", source=self.input_source
-                    )
-                )
+                st.error(get_warning_message("unsupported_input_source", source=self.input_source))
 
         except Exception as e:
             st.error(get_warning_message("input_processing_error", error=str(e)))
@@ -3058,9 +3051,7 @@ class Detection_UI:
             # 计算预估时间
             estimated_time_per_image = 2.0  # 假设每张图片需要2秒
             estimated_total_time = total_files * estimated_time_per_image
-            status_text.write(
-                get_file_message("estimated_time", time=estimated_total_time)
-            )
+            status_text.write(get_file_message("estimated_time", time=estimated_total_time))
 
             start_time = time.time()
             successful_count = 0
@@ -3090,13 +3081,13 @@ class Detection_UI:
                         uploaded_file.seek(0)
                         source_img = uploaded_file.read()
                         file_name = uploaded_file.name
-
+                        
                         # 为上传的文件创建临时文件以获取完整路径
                         if getattr(self, "enable_gps_parsing", False):
                             # 创建临时文件保存图片，以便GPS解析
                             temp_dir = tempfile.mkdtemp()
                             temp_file_path = os.path.join(temp_dir, file_name)
-                            with open(temp_file_path, "wb") as temp_file:
+                            with open(temp_file_path, 'wb') as temp_file:
                                 temp_file.write(source_img)
                             img_path = temp_file_path
                     else:
@@ -3111,9 +3102,7 @@ class Detection_UI:
                     image_ini = cv2.imdecode(file_bytes, 1)
 
                     if image_ini is None:
-                        st.error(
-                            get_file_message("image_decode_error", filename=file_name)
-                        )
+                        st.error(get_file_message("image_decode_error", filename=file_name))
                         failed_count += 1
                         continue
 
@@ -3122,9 +3111,7 @@ class Detection_UI:
 
                     # 进行检测
                     framecopy = processed_image.copy()
-                    image, detInfo, select_info = self.frame_process(
-                        framecopy, file_name
-                    )
+                    image, detInfo, select_info = self.frame_process(framecopy, file_name)
 
                     # 保存结果
                     save_chinese_image(self.output_path + "/image/" + file_name, image)
@@ -3135,23 +3122,13 @@ class Detection_UI:
                     st.session_state["current_detection_time"] = self.detection_time
 
                     # 更新显示
-                    self.frame_count_placeholder.metric(
-                        get_main_label("current_frame"), idx + 1
-                    )
-                    self.target_count_placeholder.metric(
-                        get_main_label("target_count"), len(detInfo)
-                    )
-                    self.detection_time_placeholder.metric(
-                        get_main_label("detection_time"), self.detection_time
-                    )
+                    self.frame_count_placeholder.metric(get_main_label("current_frame"), idx + 1)
+                    self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
+                    self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
 
                     # 显示图片
-                    resized_image = cv2.resize(
-                        image, (self.display_width, self.display_height)
-                    )
-                    resized_frame = cv2.resize(
-                        processed_image, (self.display_width, self.display_height)
-                    )
+                    resized_image = cv2.resize(image, (self.display_width, self.display_height))
+                    resized_frame = cv2.resize(processed_image, (self.display_width, self.display_height))
 
                     if self.display_mode == "叠加显示":
                         self.image_placeholder.image(
@@ -3173,9 +3150,7 @@ class Detection_UI:
                             )
 
                     # 添加到日志表（现在img_path不为None）
-                    self.logTable.add_frames(
-                        image, detInfo, processed_image, file_name, img_path
-                    )
+                    self.logTable.add_frames(image, detInfo, processed_image, file_name, img_path)
 
                     successful_count += 1
 
@@ -3214,7 +3189,7 @@ class Detection_UI:
 
             # 完成后的总结
             total_time = time.time() - start_time
-
+            
             # 🔧 在终端输出完成信息
             print(f"🎉 批量检测完成！")
             print(f"🏁 批量处理完成")
@@ -3223,13 +3198,13 @@ class Detection_UI:
             print(f"   - 失败处理: {failed_count}张")
             print(f"   - 总耗时: {total_time:.2f}秒")
             print(f"   - 平均耗时: {total_time/total_files:.2f}秒/张")
-
+            
             if failed_count > 0:
                 print(f"⚠️  有{failed_count}张图片处理失败，请检查上述错误信息")
-
+            
             # 生成汇总信息用于界面显示
             summary_msg = f"📊 处理完成: 成功 {successful_count} 张，失败 {failed_count} 张，总用时 {total_time:.2f} 秒"
-
+            
             # 仅在处理过程中显示完成消息，不保存到session_state
             current_image_info.success("批量处理完成！")
             status_text.success(summary_msg)
@@ -3244,9 +3219,7 @@ class Detection_UI:
             st.session_state["saved_names"] = self.logTable.saved_names.copy()
             # 同步每张图片的目标信息
             if hasattr(self.logTable, "saved_targets_info"):
-                st.session_state["saved_targets_info"] = (
-                    self.logTable.saved_targets_info.copy()
-                )
+                st.session_state["saved_targets_info"] = self.logTable.saved_targets_info.copy()
 
             # 确保索引重置为0以显示第一张图片
             st.session_state["image_play_index"] = 0
@@ -3284,7 +3257,7 @@ class Detection_UI:
                 if getattr(self, "enable_gps_parsing", False):
                     temp_dir = tempfile.mkdtemp()
                     temp_file_path = os.path.join(temp_dir, self.uploaded_file.name)
-                    with open(temp_file_path, "wb") as temp_file:
+                    with open(temp_file_path, 'wb') as temp_file:
                         temp_file.write(source_img)
                     img_path = temp_file_path
 
@@ -3299,17 +3272,13 @@ class Detection_UI:
 
                 # 进行检测
                 framecopy = processed_image.copy()
-                image, detInfo, select_info = self.frame_process(
-                    framecopy, self.uploaded_file.name
-                )
+                image, detInfo, select_info = self.frame_process(framecopy, self.uploaded_file.name)
 
                 status_info.write(get_file_message("saving_detection_results"))
                 single_progress.progress(0.8)
 
                 # 保存结果
-                save_chinese_image(
-                    self.output_path + "/image/" + self.uploaded_file.name, image
-                )
+                save_chinese_image(self.output_path + "/image/" + self.uploaded_file.name, image)
 
                 # 更新状态
                 st.session_state["current_frame_count"] = 1
@@ -3318,20 +3287,12 @@ class Detection_UI:
 
                 # 更新显示
                 self.frame_count_placeholder.metric(get_main_label("current_frame"), 1)
-                self.target_count_placeholder.metric(
-                    get_main_label("target_count"), len(detInfo)
-                )
-                self.detection_time_placeholder.metric(
-                    get_main_label("detection_time"), self.detection_time
-                )
+                self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
+                self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
 
                 # 显示图片
-                resized_image = cv2.resize(
-                    image, (self.display_width, self.display_height)
-                )
-                resized_frame = cv2.resize(
-                    processed_image, (self.display_width, self.display_height)
-                )
+                resized_image = cv2.resize(image, (self.display_width, self.display_height))
+                resized_frame = cv2.resize(processed_image, (self.display_width, self.display_height))
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(
@@ -3353,24 +3314,18 @@ class Detection_UI:
                         )
 
                 # 添加到日志表（现在img_path不为None）
-                self.logTable.add_frames(
-                    image, detInfo, processed_image, self.uploaded_file.name, img_path
-                )
+                self.logTable.add_frames(image, detInfo, processed_image, self.uploaded_file.name, img_path)
 
                 status_info.write(get_general_message("updating_interface"))
                 single_progress.progress(0.9)
 
                 # 立即更新session state以确保UI同步
-                st.session_state["saved_images_ini"] = (
-                    self.logTable.saved_images_ini.copy()
-                )
+                st.session_state["saved_images_ini"] = self.logTable.saved_images_ini.copy()
                 st.session_state["saved_images"] = self.logTable.saved_images.copy()
                 st.session_state["saved_names"] = self.logTable.saved_names.copy()
                 # 同步每张图片的目标信息
                 if hasattr(self.logTable, "saved_targets_info"):
-                    st.session_state["saved_targets_info"] = (
-                        self.logTable.saved_targets_info.copy()
-                    )
+                    st.session_state["saved_targets_info"] = self.logTable.saved_targets_info.copy()
 
                 # 确保索引重置为0
                 st.session_state["image_play_index"] = 0
@@ -3398,9 +3353,7 @@ class Detection_UI:
                 st.success(get_detection_message("image_detection_complete"))
 
             except Exception as e:
-                st.error(
-                    get_file_message("single_image_processing_error", error=str(e))
-                )
+                st.error(get_file_message("single_image_processing_error", error=str(e)))
 
     def _process_video_input(self):
         """
@@ -3438,9 +3391,7 @@ class Detection_UI:
 
             cap = cv2.VideoCapture(tfile.name)
             if not cap.isOpened():
-                st.error(
-                    get_video_message("video_open_failed", video_name=video_file.name)
-                )
+                st.error(get_video_message("video_open_failed", video_name=video_file.name))
                 return
 
             # 获取视频信息
@@ -3481,23 +3432,13 @@ class Detection_UI:
                 st.session_state["current_detection_time"] = self.detection_time
 
                 # 更新显示
-                self.frame_count_placeholder.metric(
-                    get_main_label("current_frame"), current_frame + 1
-                )
-                self.target_count_placeholder.metric(
-                    get_main_label("target_count"), len(detInfo)
-                )
-                self.detection_time_placeholder.metric(
-                    get_main_label("detection_time"), self.detection_time
-                )
+                self.frame_count_placeholder.metric(get_main_label("current_frame"), current_frame + 1)
+                self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
+                self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
 
                 # 显示图片
-                resized_image = cv2.resize(
-                    image, (self.display_width, self.display_height)
-                )
-                resized_frame = cv2.resize(
-                    processed_frame, (self.display_width, self.display_height)
-                )
+                resized_image = cv2.resize(image, (self.display_width, self.display_height))
+                resized_frame = cv2.resize(processed_frame, (self.display_width, self.display_height))
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(
@@ -3572,9 +3513,7 @@ class Detection_UI:
 
                 # 进行检测
                 framecopy = processed_frame.copy()
-                image, detInfo, _ = self.frame_process(
-                    framecopy, f"camera_{frame_count}"
-                )
+                image, detInfo, _ = self.frame_process(framecopy, f"camera_{frame_count}")
 
                 # 更新状态
                 st.session_state["current_frame_count"] = frame_count + 1
@@ -3582,23 +3521,13 @@ class Detection_UI:
                 st.session_state["current_detection_time"] = self.detection_time
 
                 # 更新显示
-                self.frame_count_placeholder.metric(
-                    get_main_label("current_frame"), frame_count + 1
-                )
-                self.target_count_placeholder.metric(
-                    get_main_label("target_count"), len(detInfo)
-                )
-                self.detection_time_placeholder.metric(
-                    get_main_label("detection_time"), self.detection_time
-                )
+                self.frame_count_placeholder.metric(get_main_label("current_frame"), frame_count + 1)
+                self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
+                self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
 
                 # 显示图片
-                resized_image = cv2.resize(
-                    image, (self.display_width, self.display_height)
-                )
-                resized_frame = cv2.resize(
-                    processed_frame, (self.display_width, self.display_height)
-                )
+                resized_image = cv2.resize(image, (self.display_width, self.display_height))
+                resized_frame = cv2.resize(processed_frame, (self.display_width, self.display_height))
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(
@@ -3643,9 +3572,7 @@ class Detection_UI:
                 return
 
             st.info(get_rtsp_message("rtsp_connected", rtsp_url=rtsp_url))
-            self.close_flag = self.close_placeholder.button(
-                label=get_button_text("stop")
-            )
+            self.close_flag = self.close_placeholder.button(label=get_button_text("stop"))
 
             frame_count = 0
             while cap.isOpened() and not self.close_flag:
@@ -3668,23 +3595,13 @@ class Detection_UI:
                 st.session_state["current_detection_time"] = self.detection_time
 
                 # 更新显示
-                self.frame_count_placeholder.metric(
-                    get_main_label("current_frame"), frame_count + 1
-                )
-                self.target_count_placeholder.metric(
-                    get_main_label("current_target"), len(detInfo)
-                )
-                self.detection_time_placeholder.metric(
-                    get_main_label("current_detection_time"), self.detection_time
-                )
+                self.frame_count_placeholder.metric(get_main_label("current_frame"), frame_count + 1)
+                self.target_count_placeholder.metric(get_main_label("current_target"), len(detInfo))
+                self.detection_time_placeholder.metric(get_main_label("current_detection_time"), self.detection_time)
 
                 # 显示图片
-                resized_image = cv2.resize(
-                    image, (self.display_width, self.display_height)
-                )
-                resized_frame = cv2.resize(
-                    processed_frame, (self.display_width, self.display_height)
-                )
+                resized_image = cv2.resize(image, (self.display_width, self.display_height))
+                resized_frame = cv2.resize(processed_frame, (self.display_width, self.display_height))
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(

--- a/src/web.py
+++ b/src/web.py
@@ -1,134 +1,62 @@
+import base64
+import hashlib
+import json
+import os
 import random
 import tempfile
+import threading
 import time
-import os
+import tkinter as tk
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from functools import lru_cache
+from tkinter import filedialog
+
 import cv2
-import json
 import numpy as np
 import pandas as pd
 import streamlit as st
 from QtFusion.path import abs_path
 from QtFusion.utils import drawRectBox
-from log import ResultLogger, LogTable
+
+from auth import get_access_token, verify_token
+from chinese_name_list import (EL_class_colors, EL_type, Other_class_colors,
+                               Other_type, Segmentation_class_colors,
+                               Segmentation_type, Thermo_class_colors,
+                               Thermo_type, Visible_class_colors, Visible_type)
+from image_optimizer import (get_image_optimizer, optimize_image_display,
+                             process_uploaded_images)
+from log import LogTable, ResultLogger
 from model import Web_Detector
-from chinese_name_list import (
-    EL_type,
-    EL_class_colors,
-    Thermo_type,
-    Other_type,
-    Thermo_class_colors,
-    Visible_type,
-    Visible_class_colors,
-    Segmentation_type,
-    Segmentation_class_colors,
-    Other_class_colors,
-)
-from ui_style import def_css_html
-from utils import (
-    is_black_and_white,
-    save_uploaded_file,
-    concat_results,
-    load_default_image,
-    get_camera_names,
-    draw_detections,
-    save_chinese_image,
-    format_time,
-    convert_to_pseudo_colorizer,
-    camera_undistortion,
-    auto_undistort_image,
-    rotate_image,
-    auto_keystone_correction,
-    enhance_texture,
-    fill_largest_polygon_white,
-    extract_gps_info,
-)
-from datetime import datetime
-from auth import verify_token, get_access_token
-import tkinter as tk
-from tkinter import filedialog
-from utils import LocalFileObj
-import base64
-import hashlib
-from functools import lru_cache
-import threading
-from concurrent.futures import ThreadPoolExecutor
-
-# 🚀 性能优化模块导入
-from streamlit_config import (
-    optimize_streamlit_performance,
-    setup_image_optimization,
-    add_performance_css,
-)
-
 # 📝 命名配置模块导入
-from naming_config import (
-    # 系统配置
-    SYSTEM_INFO,
-    SYSTEM_DEFAULTS,
-    # 侧边栏配置
-    SIDEBAR_HEADERS,
-    SIDEBAR_LABELS,
-    SIDEBAR_OPTIONS,
-    SIDEBAR_HINTS,
-    # 主界面配置
-    MAIN_HEADERS,
-    MAIN_LABELS,
-    MAIN_OPTIONS,
-    # 按钮配置
-    BUTTON_TEXTS,
-    # 消息配置
-    DETECTION_MESSAGES,
-    FILE_MESSAGES,
-    VIDEO_MESSAGES,
-    CAMERA_MESSAGES,
-    RTSP_MESSAGES,
-    MODEL_MESSAGES,
-    WARNING_MESSAGES,
-    GENERAL_MESSAGES,
-    EXPORT_MESSAGES,
-    # 显示配置
-    IMAGE_DISPLAY_LABELS,
-    STATISTICS_LABELS,
-    METRICS_LABELS,
-    # 数据映射
-    IMAGE_TYPE_MAP,
-    TASK_TYPE_MAP,
-    EXPORT_FORMAT_MAP,
-    # 工具函数
-    get_detection_message,
-    get_file_message,
-    get_video_message,
-    get_camera_message,
-    get_rtsp_message,
-    get_model_message,
-    get_warning_message,
-    get_general_message,
-    get_export_message,
-    get_statistic_message,
-    get_metric_label,
-    generate_filename,
-    # UI 获取函数
-    get_sidebar_header,
-    get_sidebar_label,
-    get_sidebar_option,
-    get_sidebar_hint,
-    get_main_header,
-    get_main_label,
-    get_main_option,
-    get_button_text,
-    get_image_display_label,
-    get_statistic_label,
-    # 兼容性支持
-    STATUS_MESSAGES,
-    UI_LABELS,
-    UI_OPTIONS,
-    get_status_message,
-)
-from image_optimizer import (
-    get_image_optimizer,
-    optimize_image_display,
-    process_uploaded_images,
-)
+from naming_config import (  # 系统配置; 侧边栏配置; 主界面配置; 按钮配置; 消息配置; 显示配置; 数据映射; 工具函数; UI 获取函数; 兼容性支持
+    BUTTON_TEXTS, CAMERA_MESSAGES, DETECTION_MESSAGES, EXPORT_FORMAT_MAP,
+    EXPORT_MESSAGES, FILE_MESSAGES, GENERAL_MESSAGES, IMAGE_DISPLAY_LABELS,
+    IMAGE_TYPE_MAP, MAIN_HEADERS, MAIN_LABELS, MAIN_OPTIONS, METRICS_LABELS,
+    MODEL_MESSAGES, RTSP_MESSAGES, SIDEBAR_HEADERS, SIDEBAR_HINTS,
+    SIDEBAR_LABELS, SIDEBAR_OPTIONS, STATISTICS_LABELS, STATUS_MESSAGES,
+    SYSTEM_DEFAULTS, SYSTEM_INFO, TASK_TYPE_MAP, UI_LABELS, UI_OPTIONS,
+    VIDEO_MESSAGES, WARNING_MESSAGES, generate_filename, get_button_text,
+    get_camera_message, get_detection_message, get_export_message,
+    get_file_message, get_general_message, get_image_display_label,
+    get_main_header, get_main_label, get_main_option, get_metric_label,
+    get_model_message, get_rtsp_message, get_sidebar_header, get_sidebar_hint,
+    get_sidebar_label, get_sidebar_option, get_statistic_label,
+    get_statistic_message, get_status_message, get_video_message,
+    get_warning_message)
+# 🚀 性能优化模块导入
+from streamlit_config import (add_performance_css,
+                              optimize_streamlit_performance,
+                              setup_image_optimization)
+from ui_style import def_css_html
+from utils import (LocalFileObj, auto_keystone_correction,
+                   auto_undistort_image, camera_undistortion,
+                   compute_inclusion_relations, concat_results,
+                   convert_to_pseudo_colorizer, draw_detections,
+                   enhance_texture, extract_gps_info,
+                   fill_largest_polygon_white, format_time, get_camera_names,
+                   is_black_and_white, load_default_image, rotate_image,
+                   save_chinese_image, save_uploaded_file)
 
 
 # 🚀 性能优化：添加缓存装饰器
@@ -353,6 +281,10 @@ class Detection_UI:
         self.gps_lon_placeholder = None
         self.gps_alt_placeholder = None
         self.gps_time_placeholder = None
+        # 包含关系表格占位符
+        self.inclusion_table_placeholder = None
+        # 是否显示包含关系
+        self.show_inclusion = False
 
         self.new_width = 1080
         self.new_height = int(self.new_width * (9 / 16))
@@ -753,9 +685,16 @@ class Detection_UI:
         self.enable_gps_parsing = st.sidebar.checkbox(
             get_sidebar_label("enable_gps_parsing"),
             value=True,
-            help="勾选时，将解析图片的RTK GPS信息并在主页面显示"
+            help="勾选时，将解析图片的RTK GPS信息并在主页面显示",
         )
         st.sidebar.caption(get_sidebar_hint("gps_parsing_hint"))
+
+        # 是否显示分割包含关系
+        self.show_inclusion = st.sidebar.checkbox(
+            get_sidebar_label("show_inclusion_relationship"),
+            value=False,
+        )
+        st.sidebar.caption(get_sidebar_hint("inclusion_relationship_hint"))
 
         # 根据用户选择的导出格式设置文件后缀
         if self.export_format == "CSV":
@@ -878,9 +817,9 @@ class Detection_UI:
             self.detect_class_color = Segmentation_class_colors
 
         # 提示用户选择的图像类型
-        st.sidebar.caption(get_sidebar_hint("image_type_hint").format(
-            type=self.image_type
-        ))
+        st.sidebar.caption(
+            get_sidebar_hint("image_type_hint").format(type=self.image_type)
+        )
 
         # 设置侧边栏的选择需要检测的目标类别部分，默认选择所有类别
         st.sidebar.header(get_sidebar_header("target_class_selection"))
@@ -1255,9 +1194,7 @@ class Detection_UI:
                 # 转为文件对象
                 self.uploaded_video = [LocalFileObj(f) for f in video_files]
             else:
-                st.sidebar.caption(
-                    get_sidebar_hint("video_folder_selection_hint")
-                )
+                st.sidebar.caption(get_sidebar_hint("video_folder_selection_hint"))
                 self.uploaded_video = []
 
         # 清空按钮
@@ -1410,7 +1347,9 @@ class Detection_UI:
                     self.calibration_file = calibration_file.name
                     st.sidebar.success(get_camera_message("camera_calibration_success"))
                 except Exception as e:
-                    st.sidebar.error(get_camera_message("camera_calibration_failed", error=e))
+                    st.sidebar.error(
+                        get_camera_message("camera_calibration_failed", error=e)
+                    )
             elif calibration_input.strip():
                 try:
                     # 尝试先用json解析，否则用eval（仅限受信环境）
@@ -1420,14 +1359,18 @@ class Detection_UI:
                         calib_data = eval(calibration_input, {"__builtins__": {}})
                     self.calibration_file = "sidebar_input"
                 except Exception as e:
-                    st.sidebar.error(get_camera_message("camera_calibration_failed", error=e))
+                    st.sidebar.error(
+                        get_camera_message("camera_calibration_failed", error=e)
+                    )
             if calib_data is not None:
                 try:
                     self.camera_matrix = np.array(calib_data["camera_matrix"])
                     self.dist_coeffs = np.array(calib_data["dist_coeffs"])
                     st.sidebar.success(get_camera_message("camera_calibration_success"))
                 except Exception as e:
-                    st.sidebar.error(get_camera_message("camera_calibration_failed", error=e))
+                    st.sidebar.error(
+                        get_camera_message("camera_calibration_failed", error=e)
+                    )
                     self.camera_matrix = None
                     self.dist_coeffs = None
                     self.calibration_file = None
@@ -1609,7 +1552,9 @@ class Detection_UI:
 
                 except Exception as e:
                     st.sidebar.error(
-                        get_file_message("image_processing_error", filename=file_name, error=str(e))
+                        get_file_message(
+                            "image_processing_error", filename=file_name, error=str(e)
+                        )
                     )
 
             else:  # Handle single file upload
@@ -2052,9 +1997,7 @@ class Detection_UI:
             return
 
         # 获取当前选中的目标过滤选项（多选）
-        selected_targets = st.session_state.get(
-            "multiselect_target", []
-        )
+        selected_targets = st.session_state.get("multiselect_target", [])
 
         # 获取原始帧
         frame = saved_images_ini[frame_id]  # 获取指定帧的初始图像
@@ -2078,7 +2021,8 @@ class Detection_UI:
                         # 如果选择了目标过滤，跳过不匹配的目标
                         if (
                             selected_targets  # 如果有选中的目标
-                            and chinese_name not in selected_targets  # 且当前目标不在选中列表中
+                            and chinese_name
+                            not in selected_targets  # 且当前目标不在选中列表中
                         ):
                             continue
 
@@ -2117,14 +2061,20 @@ class Detection_UI:
 
         # 调整图像大小
         if hasattr(self, "optimized_image_resize"):
-            resized_image = self.optimized_image_resize(image, self.display_width, self.display_height)
-            resized_frame = self.optimized_image_resize(frame, self.display_width, self.display_height)
+            resized_image = self.optimized_image_resize(
+                image, self.display_width, self.display_height
+            )
+            resized_frame = self.optimized_image_resize(
+                frame, self.display_width, self.display_height
+            )
         else:
             resized_image = cv2.resize(image, (self.display_width, self.display_height))
             resized_frame = cv2.resize(frame, (self.display_width, self.display_height))
 
         # 更新表格数据
-        detection_results = (saved_results[frame_id] if frame_id < len(saved_results) else [])
+        detection_results = (
+            saved_results[frame_id] if frame_id < len(saved_results) else []
+        )
 
         if detection_results:
             # 使用列表推导式提高性能
@@ -2148,6 +2098,17 @@ class Detection_UI:
                     )
                 self.table_placeholder.table(disp_res.results_df)
                 self.update_category_counts(frame_id)
+                if (
+                    getattr(self, "show_inclusion", False)
+                    and self.model_type == SYSTEM_DEFAULTS["model_type_segmentation"]
+                ):
+                    inclusion_df = compute_inclusion_relations(filtered_results)
+                    if inclusion_df.empty:
+                        inclusion_df = pd.DataFrame(columns=["组串编号", "包含组件数"])
+                    if hasattr(self, "inclusion_table_placeholder"):
+                        self.inclusion_table_placeholder.table(inclusion_df)
+                elif hasattr(self, "inclusion_table_placeholder"):
+                    self.inclusion_table_placeholder.empty()
             else:
                 if hasattr(self, "table_placeholder"):
                     self.table_placeholder.table(
@@ -2162,6 +2123,8 @@ class Detection_UI:
                         )
                     )
                 self.update_category_counts(frame_id)
+                if hasattr(self, "inclusion_table_placeholder"):
+                    self.inclusion_table_placeholder.empty()
         else:
             if hasattr(self, "table_placeholder"):
                 self.table_placeholder.table(
@@ -2224,15 +2187,15 @@ class Detection_UI:
                         if gps:
                             if "latitude" in gps:
                                 lat = f"{gps['latitude']:.6f}°"
-                                if 'latitude_ref' in gps:
+                                if "latitude_ref" in gps:
                                     lat += f" {gps['latitude_ref']}"
                             if "longitude" in gps:
                                 lon = f"{gps['longitude']:.6f}°"
-                                if 'longitude_ref' in gps:
+                                if "longitude_ref" in gps:
                                     lon += f" {gps['longitude_ref']}"
                             if "altitude" in gps:
                                 alt = f"{gps['altitude']:.1f}m"
-                                if gps.get('altitude_ref') == 1:
+                                if gps.get("altitude_ref") == 1:
                                     alt += " (海平面以下)"
                                 else:
                                     alt += " (海平面以上)"
@@ -2426,7 +2389,9 @@ class Detection_UI:
         detection_time = "0.00s"
 
         # 使用 display_detection_results 函数显示结果
-        res = concat_results(detection_result, detection_location, detection_confidence, detection_time)
+        res = concat_results(
+            detection_result, detection_location, detection_confidence, detection_time
+        )
         self.table_placeholder.table(res)
         # 注意：这里是演示模式，不需要更新类别统计
         # 添加适当的延迟
@@ -2435,15 +2400,21 @@ class Detection_UI:
     def update_category_counts(self, current_frame_id=None):
         """更新并显示类别计数表格"""
         # 🔧 修复：添加安全检查，确保占位符存在
-        if not hasattr(self, "current_image_category_placeholder") or self.current_image_category_placeholder is None:
+        if (
+            not hasattr(self, "current_image_category_placeholder")
+            or self.current_image_category_placeholder is None
+        ):
             return
-        if not hasattr(self, "total_category_placeholder") or self.total_category_placeholder is None:
+        if (
+            not hasattr(self, "total_category_placeholder")
+            or self.total_category_placeholder is None
+        ):
             return
 
         # 获取当前图片的类别统计
         if current_frame_id is not None:
             self.update_current_image_category_counts(current_frame_id)
-        
+
         # 获取总体类别统计
         self.update_total_category_counts()
 
@@ -2453,20 +2424,24 @@ class Detection_UI:
             # 获取当前图片的检测结果
             saved_results = getattr(self.logTable, "saved_results", [])
             saved_names = st.session_state.get("saved_names", [])
-            
+
             if frame_id >= len(saved_results) or not saved_results[frame_id]:
                 # 如果没有检测结果，显示空表格
                 empty_df = pd.DataFrame(columns=["类别", "数量"])
                 self.current_image_category_placeholder.table(empty_df)
                 return
-            
+
             # 获取当前图片名称
-            img_name = saved_names[frame_id] if frame_id < len(saved_names) else f"图片_{frame_id+1}"
-            
+            img_name = (
+                saved_names[frame_id]
+                if frame_id < len(saved_names)
+                else f"图片_{frame_id+1}"
+            )
+
             # 统计当前图片的类别
             current_results = saved_results[frame_id]
             category_counts = {}
-            
+
             for detInfo in current_results:
                 if isinstance(detInfo, list) and len(detInfo) >= 2:
                     category = detInfo[1]  # 类别名称在索引1
@@ -2474,44 +2449,58 @@ class Detection_UI:
                         category_counts[category] += 1
                     else:
                         category_counts[category] = 1
-            
+
             # 转换为DataFrame
             if category_counts:
-                current_counts = pd.DataFrame(list(category_counts.items()), columns=["类别", "数量"])
+                current_counts = pd.DataFrame(
+                    list(category_counts.items()), columns=["类别", "数量"]
+                )
                 current_counts = current_counts.sort_values("数量", ascending=False)
             else:
                 current_counts = pd.DataFrame(columns=["类别", "数量"])
-            
+
             # 添加表格标题信息
             if not current_counts.empty:
-                self.current_image_category_placeholder.write(f"📊 **{img_name}** 中检测到的目标:")
+                self.current_image_category_placeholder.write(
+                    f"📊 **{img_name}** 中检测到的目标:"
+                )
                 self.current_image_category_placeholder.table(current_counts)
             else:
-                self.current_image_category_placeholder.write(f"📊 **{img_name}** 中未检测到目标")
-                self.current_image_category_placeholder.table(pd.DataFrame(columns=["类别", "数量"]))
-                
+                self.current_image_category_placeholder.write(
+                    f"📊 **{img_name}** 中未检测到目标"
+                )
+                self.current_image_category_placeholder.table(
+                    pd.DataFrame(columns=["类别", "数量"])
+                )
+
         except Exception as e:
             st.error(f"更新当前图片类别统计时出错: {str(e)}")
-            self.current_image_category_placeholder.table(pd.DataFrame(columns=["类别", "数量"]))
+            self.current_image_category_placeholder.table(
+                pd.DataFrame(columns=["类别", "数量"])
+            )
 
     def update_total_category_counts(self):
         """更新总体类别统计，包含图片来源信息"""
         try:
             saved_results = getattr(self.logTable, "saved_results", [])
             saved_names = st.session_state.get("saved_names", [])
-            
+
             if not saved_results:
                 # 如果没有检测结果，显示空表格
                 empty_df = pd.DataFrame(columns=["类别", "总数量", "分布图片"])
                 self.total_category_placeholder.table(empty_df)
                 return
-            
+
             # 统计每个类别在各图片中的分布
             category_distribution = {}
-            
+
             for frame_id, results in enumerate(saved_results):
-                img_name = saved_names[frame_id] if frame_id < len(saved_names) else f"图片_{frame_id+1}"
-                
+                img_name = (
+                    saved_names[frame_id]
+                    if frame_id < len(saved_names)
+                    else f"图片_{frame_id+1}"
+                )
+
                 if results:
                     frame_categories = {}
                     for detInfo in results:
@@ -2521,33 +2510,43 @@ class Detection_UI:
                                 frame_categories[category] += 1
                             else:
                                 frame_categories[category] = 1
-                    
+
                     # 记录每个类别在当前图片中的分布
                     for category, count in frame_categories.items():
                         if category not in category_distribution:
                             category_distribution[category] = []
                         category_distribution[category].append(f"{img_name}({count})")
-            
+
             # 转换为DataFrame
             if category_distribution:
                 total_data = []
                 for category, distribution in category_distribution.items():
-                    total_count = sum(int(item.split('(')[1].split(')')[0]) for item in distribution)
+                    total_count = sum(
+                        int(item.split("(")[1].split(")")[0]) for item in distribution
+                    )
                     distribution_str = ", ".join(distribution)
                     total_data.append([category, total_count, distribution_str])
-                
-                total_counts = pd.DataFrame(total_data, columns=["类别", "总数量", "分布图片"])
+
+                total_counts = pd.DataFrame(
+                    total_data, columns=["类别", "总数量", "分布图片"]
+                )
                 total_counts = total_counts.sort_values("总数量", ascending=False)
-                
-                self.total_category_placeholder.write(f"📈 **总体统计** (共{len(saved_results)}张图片):")
+
+                self.total_category_placeholder.write(
+                    f"📈 **总体统计** (共{len(saved_results)}张图片):"
+                )
                 self.total_category_placeholder.table(total_counts)
             else:
                 self.total_category_placeholder.write("📈 **总体统计**: 暂无检测结果")
-                self.total_category_placeholder.table(pd.DataFrame(columns=["类别", "总数量", "分布图片"]))
-                
+                self.total_category_placeholder.table(
+                    pd.DataFrame(columns=["类别", "总数量", "分布图片"])
+                )
+
         except Exception as e:
             st.error(f"更新总体类别统计时出错: {str(e)}")
-            self.total_category_placeholder.table(pd.DataFrame(columns=["类别", "总数量", "分布图片"]))
+            self.total_category_placeholder.table(
+                pd.DataFrame(columns=["类别", "总数量", "分布图片"])
+            )
 
     def setupMainWindow(self):
         """
@@ -2627,11 +2626,14 @@ class Detection_UI:
             st.subheader(get_main_header("current_image_results"))
             self.table_placeholder = st.empty()  # 调整到最右侧显示
             self.table_placeholder.table(res)
-            
+
             # 在当前图片检测结果下方添加当前图片类别统计
             st.subheader(get_main_header("current_category_statistics"))
             self.current_image_category_placeholder = st.empty()
-            
+
+            st.subheader(get_main_header("inclusion_relationship"))
+            self.inclusion_table_placeholder = st.empty()
+
             # 目标过滤选项（针对当前图片）
             st.subheader(get_main_label("target_filter"))
             self.selectbox_placeholder = st.empty()
@@ -2652,15 +2654,23 @@ class Detection_UI:
                 detected_targets = st.session_state.get("select_info", ["全部目标"])
 
             # 从检测目标列表中移除"全部目标"，只保留实际的类别名称
-            available_targets = [target for target in detected_targets if target != "全部目标"]
+            available_targets = [
+                target for target in detected_targets if target != "全部目标"
+            ]
 
             # multiselect动态key，确保当目标列表变化时multiselect会刷新
-            multiselect_key = f"multiselect_target_{idx}_{hash(tuple(available_targets))}"
+            multiselect_key = (
+                f"multiselect_target_{idx}_{hash(tuple(available_targets))}"
+            )
 
             # 确保当前选中的目标在新的目标列表中，默认选择所有可用目标
-            current_selected = st.session_state.get("multiselect_target", available_targets.copy())
+            current_selected = st.session_state.get(
+                "multiselect_target", available_targets.copy()
+            )
             # 过滤掉不在当前目标列表中的选项
-            current_selected = [target for target in current_selected if target in available_targets]
+            current_selected = [
+                target for target in current_selected if target in available_targets
+            ]
             # 如果没有选中任何目标，默认选择所有目标
             if not current_selected:
                 current_selected = available_targets.copy()
@@ -2670,7 +2680,9 @@ class Detection_UI:
                 col_select_all, col_select_none = st.columns(2)
                 with col_select_all:
                     if st.button("全选", key=f"select_all_{idx}"):
-                        st.session_state["multiselect_target"] = available_targets.copy()
+                        st.session_state["multiselect_target"] = (
+                            available_targets.copy()
+                        )
                         st.rerun()
                 with col_select_none:
                     if st.button("全不选", key=f"select_none_{idx}"):
@@ -2693,14 +2705,14 @@ class Detection_UI:
                 st.session_state["multiselect_target"] = selected_targets
                 st.session_state["last_selected_targets"] = selected_targets
                 self.toggle_comboBox(idx)
-            
+
         # 图片浏览控制（移动到总体类别统计上方）
         st.markdown("---")
-        
+
         # 显示批量处理汇总信息（如果存在）
         if st.session_state.get("batch_processing_summary"):
             st.success(st.session_state["batch_processing_summary"])
-        
+
         st.subheader(get_main_header("image_browser_control"))
 
         # 检查是否有检测结果（优先检查session state，然后检查logTable）
@@ -2709,7 +2721,9 @@ class Detection_UI:
             saved_images_ini = self.logTable.saved_images_ini
             # 同步到session state
             st.session_state["saved_images_ini"] = saved_images_ini
-            st.session_state["saved_images"] = getattr(self.logTable, "saved_images", [])
+            st.session_state["saved_images"] = getattr(
+                self.logTable, "saved_images", []
+            )
             st.session_state["saved_names"] = getattr(self.logTable, "saved_names", [])
 
         if len(saved_images_ini) > 0:
@@ -2737,11 +2751,17 @@ class Detection_UI:
                     st.rerun()
 
             with col_info:
-                st.write(get_statistic_message("image_index_info", current=current_index + 1, total=total_imgs))
+                st.write(
+                    get_statistic_message(
+                        "image_index_info", current=current_index + 1, total=total_imgs
+                    )
+                )
                 # 显示当前图片名称
                 if current_index < len(st.session_state.get("saved_names", [])):
                     img_name = st.session_state["saved_names"][current_index]
-                    st.caption(get_statistic_message("filename_info", filename=img_name))
+                    st.caption(
+                        get_statistic_message("filename_info", filename=img_name)
+                    )
 
             with col_next:
                 if st.button(
@@ -2749,7 +2769,9 @@ class Detection_UI:
                     key="next_btn",
                     disabled=(current_index >= total_imgs - 1),
                 ):
-                    st.session_state["image_play_index"] = min(total_imgs - 1, current_index + 1)
+                    st.session_state["image_play_index"] = min(
+                        total_imgs - 1, current_index + 1
+                    )
                     st.rerun()
 
             # 添加滑块控制
@@ -2770,18 +2792,24 @@ class Detection_UI:
             st.info(get_detection_message("no_detection_results"))
             # 显示默认图像
             if hasattr(self, "image_placeholder"):
-                self.image_placeholder.image(load_default_image(), caption=get_image_display_label("original_view"))
+                self.image_placeholder.image(
+                    load_default_image(),
+                    caption=get_image_display_label("original_view"),
+                )
                 if self.display_mode == "对比显示" and hasattr(
                     self, "image_placeholder_res"
                 ):
-                    self.image_placeholder_res.image(load_default_image(), caption=get_image_display_label("detection_view"))
+                    self.image_placeholder_res.image(
+                        load_default_image(),
+                        caption=get_image_display_label("detection_view"),
+                    )
 
         # 🔧 修复：在创建占位符后再调用update_category_counts
         st.subheader(get_main_header("total_category_statistics"))
-        
+
         # 总体类别统计
         self.total_category_placeholder = st.empty()
-        
+
         # 初始化类别统计（使用当前图片索引）
         current_idx = st.session_state.get("image_play_index", 0)
         self.update_category_counts(current_idx)
@@ -2861,7 +2889,9 @@ class Detection_UI:
 
         with col1:
             st.write("")
-            run_button = st.button(get_button_text("start_detection"), key="main_start_detection")
+            run_button = st.button(
+                get_button_text("start_detection"), key="main_start_detection"
+            )
             self.close_placeholder = st.empty()
 
         st.subheader(get_main_header("realtime_dashboard"))
@@ -2954,7 +2984,11 @@ class Detection_UI:
                     st.warning(get_rtsp_message("input_rtsp_first"))
 
             else:
-                st.error(get_warning_message("unsupported_input_source", source=self.input_source))
+                st.error(
+                    get_warning_message(
+                        "unsupported_input_source", source=self.input_source
+                    )
+                )
 
         except Exception as e:
             st.error(get_warning_message("input_processing_error", error=str(e)))
@@ -3024,7 +3058,9 @@ class Detection_UI:
             # 计算预估时间
             estimated_time_per_image = 2.0  # 假设每张图片需要2秒
             estimated_total_time = total_files * estimated_time_per_image
-            status_text.write(get_file_message("estimated_time", time=estimated_total_time))
+            status_text.write(
+                get_file_message("estimated_time", time=estimated_total_time)
+            )
 
             start_time = time.time()
             successful_count = 0
@@ -3054,13 +3090,13 @@ class Detection_UI:
                         uploaded_file.seek(0)
                         source_img = uploaded_file.read()
                         file_name = uploaded_file.name
-                        
+
                         # 为上传的文件创建临时文件以获取完整路径
                         if getattr(self, "enable_gps_parsing", False):
                             # 创建临时文件保存图片，以便GPS解析
                             temp_dir = tempfile.mkdtemp()
                             temp_file_path = os.path.join(temp_dir, file_name)
-                            with open(temp_file_path, 'wb') as temp_file:
+                            with open(temp_file_path, "wb") as temp_file:
                                 temp_file.write(source_img)
                             img_path = temp_file_path
                     else:
@@ -3075,7 +3111,9 @@ class Detection_UI:
                     image_ini = cv2.imdecode(file_bytes, 1)
 
                     if image_ini is None:
-                        st.error(get_file_message("image_decode_error", filename=file_name))
+                        st.error(
+                            get_file_message("image_decode_error", filename=file_name)
+                        )
                         failed_count += 1
                         continue
 
@@ -3084,7 +3122,9 @@ class Detection_UI:
 
                     # 进行检测
                     framecopy = processed_image.copy()
-                    image, detInfo, select_info = self.frame_process(framecopy, file_name)
+                    image, detInfo, select_info = self.frame_process(
+                        framecopy, file_name
+                    )
 
                     # 保存结果
                     save_chinese_image(self.output_path + "/image/" + file_name, image)
@@ -3095,13 +3135,23 @@ class Detection_UI:
                     st.session_state["current_detection_time"] = self.detection_time
 
                     # 更新显示
-                    self.frame_count_placeholder.metric(get_main_label("current_frame"), idx + 1)
-                    self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
-                    self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
+                    self.frame_count_placeholder.metric(
+                        get_main_label("current_frame"), idx + 1
+                    )
+                    self.target_count_placeholder.metric(
+                        get_main_label("target_count"), len(detInfo)
+                    )
+                    self.detection_time_placeholder.metric(
+                        get_main_label("detection_time"), self.detection_time
+                    )
 
                     # 显示图片
-                    resized_image = cv2.resize(image, (self.display_width, self.display_height))
-                    resized_frame = cv2.resize(processed_image, (self.display_width, self.display_height))
+                    resized_image = cv2.resize(
+                        image, (self.display_width, self.display_height)
+                    )
+                    resized_frame = cv2.resize(
+                        processed_image, (self.display_width, self.display_height)
+                    )
 
                     if self.display_mode == "叠加显示":
                         self.image_placeholder.image(
@@ -3123,7 +3173,9 @@ class Detection_UI:
                             )
 
                     # 添加到日志表（现在img_path不为None）
-                    self.logTable.add_frames(image, detInfo, processed_image, file_name, img_path)
+                    self.logTable.add_frames(
+                        image, detInfo, processed_image, file_name, img_path
+                    )
 
                     successful_count += 1
 
@@ -3162,7 +3214,7 @@ class Detection_UI:
 
             # 完成后的总结
             total_time = time.time() - start_time
-            
+
             # 🔧 在终端输出完成信息
             print(f"🎉 批量检测完成！")
             print(f"🏁 批量处理完成")
@@ -3171,13 +3223,13 @@ class Detection_UI:
             print(f"   - 失败处理: {failed_count}张")
             print(f"   - 总耗时: {total_time:.2f}秒")
             print(f"   - 平均耗时: {total_time/total_files:.2f}秒/张")
-            
+
             if failed_count > 0:
                 print(f"⚠️  有{failed_count}张图片处理失败，请检查上述错误信息")
-            
+
             # 生成汇总信息用于界面显示
             summary_msg = f"📊 处理完成: 成功 {successful_count} 张，失败 {failed_count} 张，总用时 {total_time:.2f} 秒"
-            
+
             # 仅在处理过程中显示完成消息，不保存到session_state
             current_image_info.success("批量处理完成！")
             status_text.success(summary_msg)
@@ -3192,7 +3244,9 @@ class Detection_UI:
             st.session_state["saved_names"] = self.logTable.saved_names.copy()
             # 同步每张图片的目标信息
             if hasattr(self.logTable, "saved_targets_info"):
-                st.session_state["saved_targets_info"] = self.logTable.saved_targets_info.copy()
+                st.session_state["saved_targets_info"] = (
+                    self.logTable.saved_targets_info.copy()
+                )
 
             # 确保索引重置为0以显示第一张图片
             st.session_state["image_play_index"] = 0
@@ -3230,7 +3284,7 @@ class Detection_UI:
                 if getattr(self, "enable_gps_parsing", False):
                     temp_dir = tempfile.mkdtemp()
                     temp_file_path = os.path.join(temp_dir, self.uploaded_file.name)
-                    with open(temp_file_path, 'wb') as temp_file:
+                    with open(temp_file_path, "wb") as temp_file:
                         temp_file.write(source_img)
                     img_path = temp_file_path
 
@@ -3245,13 +3299,17 @@ class Detection_UI:
 
                 # 进行检测
                 framecopy = processed_image.copy()
-                image, detInfo, select_info = self.frame_process(framecopy, self.uploaded_file.name)
+                image, detInfo, select_info = self.frame_process(
+                    framecopy, self.uploaded_file.name
+                )
 
                 status_info.write(get_file_message("saving_detection_results"))
                 single_progress.progress(0.8)
 
                 # 保存结果
-                save_chinese_image(self.output_path + "/image/" + self.uploaded_file.name, image)
+                save_chinese_image(
+                    self.output_path + "/image/" + self.uploaded_file.name, image
+                )
 
                 # 更新状态
                 st.session_state["current_frame_count"] = 1
@@ -3260,12 +3318,20 @@ class Detection_UI:
 
                 # 更新显示
                 self.frame_count_placeholder.metric(get_main_label("current_frame"), 1)
-                self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
-                self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
+                self.target_count_placeholder.metric(
+                    get_main_label("target_count"), len(detInfo)
+                )
+                self.detection_time_placeholder.metric(
+                    get_main_label("detection_time"), self.detection_time
+                )
 
                 # 显示图片
-                resized_image = cv2.resize(image, (self.display_width, self.display_height))
-                resized_frame = cv2.resize(processed_image, (self.display_width, self.display_height))
+                resized_image = cv2.resize(
+                    image, (self.display_width, self.display_height)
+                )
+                resized_frame = cv2.resize(
+                    processed_image, (self.display_width, self.display_height)
+                )
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(
@@ -3287,18 +3353,24 @@ class Detection_UI:
                         )
 
                 # 添加到日志表（现在img_path不为None）
-                self.logTable.add_frames(image, detInfo, processed_image, self.uploaded_file.name, img_path)
+                self.logTable.add_frames(
+                    image, detInfo, processed_image, self.uploaded_file.name, img_path
+                )
 
                 status_info.write(get_general_message("updating_interface"))
                 single_progress.progress(0.9)
 
                 # 立即更新session state以确保UI同步
-                st.session_state["saved_images_ini"] = self.logTable.saved_images_ini.copy()
+                st.session_state["saved_images_ini"] = (
+                    self.logTable.saved_images_ini.copy()
+                )
                 st.session_state["saved_images"] = self.logTable.saved_images.copy()
                 st.session_state["saved_names"] = self.logTable.saved_names.copy()
                 # 同步每张图片的目标信息
                 if hasattr(self.logTable, "saved_targets_info"):
-                    st.session_state["saved_targets_info"] = self.logTable.saved_targets_info.copy()
+                    st.session_state["saved_targets_info"] = (
+                        self.logTable.saved_targets_info.copy()
+                    )
 
                 # 确保索引重置为0
                 st.session_state["image_play_index"] = 0
@@ -3326,7 +3398,9 @@ class Detection_UI:
                 st.success(get_detection_message("image_detection_complete"))
 
             except Exception as e:
-                st.error(get_file_message("single_image_processing_error", error=str(e)))
+                st.error(
+                    get_file_message("single_image_processing_error", error=str(e))
+                )
 
     def _process_video_input(self):
         """
@@ -3364,7 +3438,9 @@ class Detection_UI:
 
             cap = cv2.VideoCapture(tfile.name)
             if not cap.isOpened():
-                st.error(get_video_message("video_open_failed", video_name=video_file.name))
+                st.error(
+                    get_video_message("video_open_failed", video_name=video_file.name)
+                )
                 return
 
             # 获取视频信息
@@ -3405,13 +3481,23 @@ class Detection_UI:
                 st.session_state["current_detection_time"] = self.detection_time
 
                 # 更新显示
-                self.frame_count_placeholder.metric(get_main_label("current_frame"), current_frame + 1)
-                self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
-                self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
+                self.frame_count_placeholder.metric(
+                    get_main_label("current_frame"), current_frame + 1
+                )
+                self.target_count_placeholder.metric(
+                    get_main_label("target_count"), len(detInfo)
+                )
+                self.detection_time_placeholder.metric(
+                    get_main_label("detection_time"), self.detection_time
+                )
 
                 # 显示图片
-                resized_image = cv2.resize(image, (self.display_width, self.display_height))
-                resized_frame = cv2.resize(processed_frame, (self.display_width, self.display_height))
+                resized_image = cv2.resize(
+                    image, (self.display_width, self.display_height)
+                )
+                resized_frame = cv2.resize(
+                    processed_frame, (self.display_width, self.display_height)
+                )
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(
@@ -3486,7 +3572,9 @@ class Detection_UI:
 
                 # 进行检测
                 framecopy = processed_frame.copy()
-                image, detInfo, _ = self.frame_process(framecopy, f"camera_{frame_count}")
+                image, detInfo, _ = self.frame_process(
+                    framecopy, f"camera_{frame_count}"
+                )
 
                 # 更新状态
                 st.session_state["current_frame_count"] = frame_count + 1
@@ -3494,13 +3582,23 @@ class Detection_UI:
                 st.session_state["current_detection_time"] = self.detection_time
 
                 # 更新显示
-                self.frame_count_placeholder.metric(get_main_label("current_frame"), frame_count + 1)
-                self.target_count_placeholder.metric(get_main_label("target_count"), len(detInfo))
-                self.detection_time_placeholder.metric(get_main_label("detection_time"), self.detection_time)
+                self.frame_count_placeholder.metric(
+                    get_main_label("current_frame"), frame_count + 1
+                )
+                self.target_count_placeholder.metric(
+                    get_main_label("target_count"), len(detInfo)
+                )
+                self.detection_time_placeholder.metric(
+                    get_main_label("detection_time"), self.detection_time
+                )
 
                 # 显示图片
-                resized_image = cv2.resize(image, (self.display_width, self.display_height))
-                resized_frame = cv2.resize(processed_frame, (self.display_width, self.display_height))
+                resized_image = cv2.resize(
+                    image, (self.display_width, self.display_height)
+                )
+                resized_frame = cv2.resize(
+                    processed_frame, (self.display_width, self.display_height)
+                )
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(
@@ -3545,7 +3643,9 @@ class Detection_UI:
                 return
 
             st.info(get_rtsp_message("rtsp_connected", rtsp_url=rtsp_url))
-            self.close_flag = self.close_placeholder.button(label=get_button_text("stop"))
+            self.close_flag = self.close_placeholder.button(
+                label=get_button_text("stop")
+            )
 
             frame_count = 0
             while cap.isOpened() and not self.close_flag:
@@ -3568,13 +3668,23 @@ class Detection_UI:
                 st.session_state["current_detection_time"] = self.detection_time
 
                 # 更新显示
-                self.frame_count_placeholder.metric(get_main_label("current_frame"), frame_count + 1)
-                self.target_count_placeholder.metric(get_main_label("current_target"), len(detInfo))
-                self.detection_time_placeholder.metric(get_main_label("current_detection_time"), self.detection_time)
+                self.frame_count_placeholder.metric(
+                    get_main_label("current_frame"), frame_count + 1
+                )
+                self.target_count_placeholder.metric(
+                    get_main_label("current_target"), len(detInfo)
+                )
+                self.detection_time_placeholder.metric(
+                    get_main_label("current_detection_time"), self.detection_time
+                )
 
                 # 显示图片
-                resized_image = cv2.resize(image, (self.display_width, self.display_height))
-                resized_frame = cv2.resize(processed_frame, (self.display_width, self.display_height))
+                resized_image = cv2.resize(
+                    image, (self.display_width, self.display_height)
+                )
+                resized_frame = cv2.resize(
+                    processed_frame, (self.display_width, self.display_height)
+                )
 
                 if self.display_mode == "叠加显示":
                     self.image_placeholder.image(


### PR DESCRIPTION
## Summary
- add UI labels and hints for showing segmentation inclusion relationships
- allow toggling display of component containment in sidebar
- compute containment of components within strings and show table
- refactor utils with `compute_inclusion_relations` helper

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `flake8 src` *(fails: command not found)*
- `mypy src` *(fails with many missing stubs)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'exifread')*

------
https://chatgpt.com/codex/tasks/task_e_686a3b504064832cb3b49f2b29721f70