### PR TITLE
Add English class names

### DIFF
--- a/src/chinese_name_list.py
+++ b/src/chinese_name_list.py
@@ -1,52 +1,141 @@
 # -*- coding: utf-8 -*-
 
+"""Class name mappings for different languages."""
+
+from typing import Dict
+
 from naming_config import get_current_language
 
-EL_type = {
-    'crack': "隐裂",                    # crack
-    'missing_corner': "缺角",           # Missing corner
-    'fragment': "碎片",                 # Fragment
-    'scratch': "划伤",                  # Scratch
-    'black_cell': "黑片"                # Black cell
+
+# -----------------------------
+# Chinese name dictionaries
+# -----------------------------
+EL_type_zh = {
+    "crack": "隐裂",  # crack
+    "missing_corner": "缺角",  # Missing corner
+    "fragment": "碎片",  # Fragment
+    "scratch": "划伤",  # Scratch
+    "black_cell": "黑片",  # Black cell
 }
 
-Thermo_type = {
-    'dyrb': "单一热斑",
-    'dmjrb': "大面积热斑",
-    'dyrb_ycdw': "单一热斑_异常低温",
-    'dmjrb_ycdw': "大面积热斑_异常低温",
-    'ycdw': "异常低温",
-    'dyrb_ejgdl': "单一热斑_二极管短路",
-    'ejgdl': "二极管短路",
-    'ygfs': "阳光反射",
-    'gfb_zc_rcx': "光伏板正常热成像",
-    'ejgdl_ycdw': "二极管短路_异常低温"
+Thermo_type_zh = {
+    "dyrb": "单一热斑",
+    "dmjrb": "大面积热斑",
+    "dyrb_ycdw": "单一热斑_异常低温",
+    "dmjrb_ycdw": "大面积热斑_异常低温",
+    "ycdw": "异常低温",
+    "dyrb_ejgdl": "单一热斑_二极管短路",
+    "ejgdl": "二极管短路",
+    "ygfs": "阳光反射",
+    "gfb_zc_rcx": "光伏板正常热成像",
+    "ejgdl_ycdw": "二极管短路_异常低温",
 }
 
-Visible_type = {
-    'yyzd': "遮挡",
-    'ygfs': "阳光反射",
-    'zw': "脏污",
-    'yyzd_zw': "遮挡_脏污",
-    'ns': "鸟粪",
-    'yyzd_ns': "遮挡_鸟粪",
-    'zw_ns': "脏污_鸟粪",
-    'gfbzjbx': "光伏板组件变形",
-    'gfbqs': "光伏板缺失",
-    'mbsl': "面板碎裂",
-    'snow': "积雪",
-    'crack': "隐裂"
+Visible_type_zh = {
+    "yyzd": "遮挡",
+    "ygfs": "阳光反射",
+    "zw": "脏污",
+    "yyzd_zw": "遮挡_脏污",
+    "ns": "鸟粪",
+    "yyzd_ns": "遮挡_鸟粪",
+    "zw_ns": "脏污_鸟粪",
+    "gfbzjbx": "光伏板组件变形",
+    "gfbqs": "光伏板缺失",
+    "mbsl": "面板碎裂",
+    "snow": "积雪",
+    "crack": "隐裂",
 }
 
-Other_type = {
-    'people': "行人",                # Person
-    'vehicle': "车辆",              # Vehicle
+Other_type_zh = {
+    "people": "行人",  # Person
+    "vehicle": "车辆",  # Vehicle
 }
 
-Segmentation_type = {
-    'component': "单组件",           # Solar panel
-    'string': "组串"              # String of solar panels
+Segmentation_type_zh = {
+    "component": "单组件",  # Solar panel
+    "string": "组串",  # String of solar panels
 }
+
+
+# -----------------------------
+# English name dictionaries
+# -----------------------------
+EL_type_en = {
+    "crack": "crack",
+    "missing_corner": "missing corner",
+    "fragment": "fragment",
+    "scratch": "scratch",
+    "black_cell": "black cell",
+}
+
+Thermo_type_en = {
+    "dyrb": "single hot spot",
+    "dmjrb": "large area hot spot",
+    "dyrb_ycdw": "single hot spot - low temp",
+    "dmjrb_ycdw": "large hot spot - low temp",
+    "ycdw": "abnormal low temp",
+    "dyrb_ejgdl": "single hot spot - diode short",
+    "ejgdl": "diode short",
+    "ygfs": "sun reflection",
+    "gfb_zc_rcx": "normal thermal imaging",
+    "ejgdl_ycdw": "diode short - low temp",
+}
+
+Visible_type_en = {
+    "yyzd": "obstruction",
+    "ygfs": "reflection",
+    "zw": "dirt",
+    "yyzd_zw": "obstruction_dirt",
+    "ns": "bird excrement",
+    "yyzd_ns": "obstruction_bird_excrement",
+    "zw_ns": "dirt_bird_excrement",
+    "gfbzjbx": "module deformation",
+    "gfbqs": "module missing",
+    "mbsl": "panel cracking",
+    "snow": "snow",
+    "crack": "crack",
+}
+
+Other_type_en = {
+    "people": "person",
+    "vehicle": "vehicle",
+}
+
+Segmentation_type_en = {
+    "component": "component",
+    "string": "string",
+}
+
+# -----------------------------
+# Globals updated by language
+# -----------------------------
+EL_type: Dict[str, str] = {}
+Thermo_type: Dict[str, str] = {}
+Visible_type: Dict[str, str] = {}
+Other_type: Dict[str, str] = {}
+Segmentation_type: Dict[str, str] = {}
+
+
+def update_class_names() -> None:
+    """Update class name dictionaries based on current language."""
+    global EL_type, Thermo_type, Visible_type, Other_type, Segmentation_type
+
+    if get_current_language() == "en":
+        EL_type = EL_type_en
+        Thermo_type = Thermo_type_en
+        Visible_type = Visible_type_en
+        Other_type = Other_type_en
+        Segmentation_type = Segmentation_type_en
+    else:
+        EL_type = EL_type_zh
+        Thermo_type = Thermo_type_zh
+        Visible_type = Visible_type_zh
+        Other_type = Other_type_zh
+        Segmentation_type = Segmentation_type_zh
+
+
+# Initialize on import
+update_class_names()
 
 EL_class_colors = {
     "crack": (0, 0, 255),                     # Red

--- a/tests/test_language_switch.py
+++ b/tests/test_language_switch.py
@@ -1,0 +1,13 @@
+import importlib
+
+from src import naming_config
+import src.chinese_name_list as cnl
+
+
+def test_language_switch():
+    naming_config.set_language('en')
+    importlib.reload(cnl)
+    assert cnl.Visible_type['yyzd'] == 'obstruction'
+    naming_config.set_language('zh')
+    importlib.reload(cnl)
+    assert cnl.Visible_type['yyzd'] == '遮挡'


### PR DESCRIPTION
## Summary
- add English mappings for detection/segmentation classes
- allow language switch to reload class names
- test language switching of class names

## Testing
- `flake8 src` *(fails: command not found)*
- `mypy src` *(fails with missing modules)*
- `pytest tests/` *(fails due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686e50fc2e60832c9aadde7232c76928