### PR TITLE
Add missing panel detection feature

### DIFF
--- a/src/chinese_name_list.py
+++ b/src/chinese_name_list.py
@@ -114,5 +114,6 @@ Other_class_colors = {
 
 Segmentation_class_colors = {
     "component": (0, 255, 0),                # Green for single solar panels
-    "string": (0, 0, 255)                      # Blue for strings
+    "string": (0, 0, 255),                     # Blue for strings
+    "missing_panel": (255, 0, 255)             # Magenta for missing panels
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,7 +90,8 @@
     "enable_rtsp_output": "Enable RTSP Output",
     "rtsp_output_url": "RTSP Output URL",
     "enable_gps_parsing": "Parse GPS",
-    "show_inclusion_relationship": "Show Inclusion Table"
+    "show_inclusion_relationship": "Show Inclusion Table",
+    "show_missing_panel": "Show Missing Modules"
   },
   "SIDEBAR_OPTIONS": {
     "aspect_ratios": ["16:9", "4:3", "Free"],
@@ -131,7 +132,8 @@
     "rtsp_output_hint": "💡 Provide RTSP/RTMP url for streaming.",
     "clear_files_success": "Files cleared!",
     "gps_parsing_hint": "💡 Parse RTK GPS info in results.",
-    "inclusion_relationship_hint": "💡 Count modules per string"
+    "inclusion_relationship_hint": "💡 Count modules per string",
+    "missing_panel_hint": "💡 Highlight missing modules within strings"
   },
   "MAIN_HEADERS": {
     "video_image_detection_system": "📷 Video/Image Detection",
@@ -343,7 +345,8 @@
     },
     "Segmentation": {
       "component": "Component",
-      "string": "String"
+      "string": "String",
+      "missing_panel": "Module Missing"
     }
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -90,7 +90,8 @@
     "enable_rtsp_output": "启用RTSP输出",
     "rtsp_output_url": "RTSP输出地址",
     "enable_gps_parsing": "解析并显示经纬度",
-    "show_inclusion_relationship": "显示包含关系表"
+    "show_inclusion_relationship": "显示包含关系表",
+    "show_missing_panel": "显示缺失组件"
   },
   "SIDEBAR_OPTIONS": {
     "aspect_ratios": [
@@ -161,7 +162,8 @@
     "rtsp_output_hint": "💡 提示: 输入RTSP/RTMP推流地址，用于实时推送检测结果视频流。",
     "clear_files_success": "已清空所有上传的文件！",
     "gps_parsing_hint": "💡 提示: 勾选后将解析图片的RTK GPS信息，在主页面与导出的报表中显示。",
-    "inclusion_relationship_hint": "💡 提示: 统计每个组串包含的单组件数量"
+    "inclusion_relationship_hint": "💡 提示: 统计每个组串包含的单组件数量",
+    "missing_panel_hint": "💡 提示: 自动圈出组串内缺失的组件"
   },
   "MAIN_HEADERS": {
     "video_image_detection_system": "📷 视频/图片检测系统",
@@ -369,7 +371,8 @@
     },
     "Segmentation": {
       "component": "单组件",
-      "string": "组串"
+      "string": "组串",
+      "missing_panel": "光伏板缺失"
     }
   }
 }

--- a/src/utils.py
+++ b/src/utils.py
@@ -796,3 +796,45 @@ def compute_inclusion_relations(detections):
         records.append([f"string_{s_idx}", count])
 
     return pd.DataFrame(records, columns=["组串编号", "包含组件数"])
+
+
+def compute_missing_panels(detections, image_shape, min_area=1000):
+    """Detect regions inside each string bbox that lack components."""
+
+    height, width = image_shape[:2]
+    strings = []
+    components = []
+
+    for det in detections:
+        if det.get("class_name") == "string":
+            strings.append(det)
+        elif det.get("class_name") == "component":
+            components.append(det)
+
+    missing = []
+    for s in strings:
+        x1_s, y1_s, x2_s, y2_s = s["bbox"]
+        mask = np.zeros((height, width), dtype=np.uint8)
+        cv2.rectangle(mask, (x1_s, y1_s), (x2_s, y2_s), 255, -1)
+
+        for c in components:
+            x1_c, y1_c, x2_c, y2_c = c["bbox"]
+            if x1_c >= x1_s and y1_c >= y1_s and x2_c <= x2_s and y2_c <= y2_s:
+                cv2.rectangle(mask, (x1_c, y1_c), (x2_c, y2_c), 0, -1)
+
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        for cnt in contours:
+            area = cv2.contourArea(cnt)
+            x, y, w, h = cv2.boundingRect(cnt)
+            if area >= min_area and not (x == x1_s and y == y1_s and x + w == x2_s and y + h == y2_s):
+                missing.append(
+                    {
+                        "class_name": "missing_panel",
+                        "bbox": [x, y, x + w, y + h],
+                        "score": 1.0,
+                        "class_id": len(detections),
+                        "mask": cnt.reshape(-1, 2),
+                    }
+                )
+
+    return missing

--- a/src/web.py
+++ b/src/web.py
@@ -323,6 +323,7 @@ class Detection_UI:
         self.gps_time_placeholder = None
         self.inclusion_table_placeholder = None
         self.show_inclusion = False
+        self.show_missing_panel = False
 
         self.new_width = 1080
         self.new_height = int(self.new_width * (9 / 16))
@@ -740,6 +741,12 @@ class Detection_UI:
             value=False,
         )
         st.sidebar.caption(get_sidebar_hint("inclusion_relationship_hint"))
+
+        self.show_missing_panel = st.sidebar.checkbox(
+            get_sidebar_label("show_missing_panel"),
+            value=False,
+        )
+        st.sidebar.caption(get_sidebar_hint("missing_panel_hint"))
 
         export_options = get_sidebar_option("export_formats")
         # 根据用户选择的导出格式设置文件后缀
@@ -2303,6 +2310,11 @@ class Detection_UI:
         # 如果有有效的检测结果
         if det is not None and len(det):
             det_info = self.model.postprocess(pred)  # 后处理预测结果
+            if (
+                self.show_missing_panel
+                and self.model_type == get_system_default("model_type_segmentation")
+            ):
+                det_info.extend(compute_missing_panels(det_info, image.shape))
             if len(det_info):
                 disp_res = ResultLogger()
                 res = None
@@ -2334,18 +2346,25 @@ class Detection_UI:
                             )
 
                     # Ensure cls_id is within bounds
-                    if cls_id >= len(self.colors):
-                        st.warning(
-                            get_warning_message(
-                                "index_out_of_range_warning", cls_id=cls_id
-                            )
-                        )
-                        color = (255, 0, 0)  # 默认红色
+                    if name == "missing_panel":
+                        color = Segmentation_class_colors.get("missing_panel", (255, 0, 255))
+                        draw_flag = self.show_missing_panel
+                        chinese_name = "光伏板缺失"
                     else:
-                        color = self.colors[cls_id]
+                        if cls_id >= len(self.colors):
+                            st.warning(
+                                get_warning_message(
+                                    "index_out_of_range_warning", cls_id=cls_id
+                                )
+                            )
+                            color = (255, 0, 0)  # 默认红色
+                        else:
+                            color = self.colors[cls_id]
+                        chinese_name = self.cls_name.get(name, "未知类别")
+                        draw_flag = name in self.selected_classes
 
                     # 🔧 确保类别匹配逻辑正确
-                    if name in self.selected_classes:
+                    if draw_flag:
                         # 绘制检测框、标签和面积信息
                         if not is_api:
                             image, aim_frame_area = draw_detections(
@@ -2365,9 +2384,6 @@ class Detection_UI:
                                 is_api=True,
                                 rectangle_bbox=self.rectangle_bounding_output,
                             )
-
-                        # 获取中文名
-                        chinese_name = self.cls_name.get(name, "未知类别")
 
                         res = disp_res.concat_results(
                             name,

--- a/tests/test_missing_panels.py
+++ b/tests/test_missing_panels.py
@@ -1,0 +1,13 @@
+import numpy as np
+from src.utils import compute_missing_panels
+
+
+def test_compute_missing_panels_basic():
+    detections = [
+        {"class_name": "string", "bbox": [0, 0, 100, 100], "score": 1.0, "class_id": 0},
+        {"class_name": "component", "bbox": [0, 0, 50, 100], "score": 1.0, "class_id": 1},
+    ]
+    missing = compute_missing_panels(detections, (100, 100, 3), min_area=10)
+    assert len(missing) == 1
+    m_bbox = missing[0]["bbox"]
+    assert m_bbox == [50, 0, 100, 100]


### PR DESCRIPTION
## Summary
- add `compute_missing_panels` utility
- extend segmentation color mappings
- translate new sidebar options and hints
- add sidebar checkbox and detection logic
- unit test for missing panel computation

## Testing
- `flake8 src` *(fails: command not found)*
- `mypy src` *(fails: many errors)*
- `pytest tests/ --cov=src --cov-report=term-missing` *(fails: unrecognized arguments)*
- `pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6874ab4e4e18832c9765879527ba9585