### PR TITLE
Add misaligned panel detection feature

### DIFF
--- a/src/chinese_name_list.py
+++ b/src/chinese_name_list.py
@@ -114,5 +114,7 @@ Other_class_colors = {
 
 Segmentation_class_colors = {
     "component": (0, 255, 0),                # Green for single solar panels
-    "string": (0, 0, 255)                      # Blue for strings
+    "string": (0, 0, 255),                     # Blue for strings
+    "missing_panel": (255, 0, 255),            # Magenta for missing panels
+    "misaligned_panel": (255, 165, 0)         # Orange for misaligned panels
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,7 +90,9 @@
     "enable_rtsp_output": "Enable RTSP Output",
     "rtsp_output_url": "RTSP Output URL",
     "enable_gps_parsing": "Parse GPS",
-    "show_inclusion_relationship": "Show Inclusion Table"
+    "show_inclusion_relationship": "Show Inclusion Table",
+    "show_missing_panel": "Show Missing Modules",
+    "show_misaligned_panel": "Show Misaligned Modules"
   },
   "SIDEBAR_OPTIONS": {
     "aspect_ratios": ["16:9", "4:3", "Free"],
@@ -131,7 +133,9 @@
     "rtsp_output_hint": "💡 Provide RTSP/RTMP url for streaming.",
     "clear_files_success": "Files cleared!",
     "gps_parsing_hint": "💡 Parse RTK GPS info in results.",
-    "inclusion_relationship_hint": "💡 Count modules per string"
+    "inclusion_relationship_hint": "💡 Count modules per string",
+    "missing_panel_hint": "💡 Highlight missing modules within strings",
+    "misaligned_panel_hint": "💡 Highlight rotated or shifted modules"
   },
   "MAIN_HEADERS": {
     "video_image_detection_system": "📷 Video/Image Detection",
@@ -343,7 +347,9 @@
     },
     "Segmentation": {
       "component": "Component",
-      "string": "String"
+      "string": "String",
+      "missing_panel": "Module Missing",
+      "misaligned_panel": "Module Misaligned"
     }
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -90,7 +90,9 @@
     "enable_rtsp_output": "启用RTSP输出",
     "rtsp_output_url": "RTSP输出地址",
     "enable_gps_parsing": "解析并显示经纬度",
-    "show_inclusion_relationship": "显示包含关系表"
+    "show_inclusion_relationship": "显示包含关系表",
+    "show_missing_panel": "显示缺失组件",
+    "show_misaligned_panel": "显示移位组件"
   },
   "SIDEBAR_OPTIONS": {
     "aspect_ratios": [
@@ -161,7 +163,9 @@
     "rtsp_output_hint": "💡 提示: 输入RTSP/RTMP推流地址，用于实时推送检测结果视频流。",
     "clear_files_success": "已清空所有上传的文件！",
     "gps_parsing_hint": "💡 提示: 勾选后将解析图片的RTK GPS信息，在主页面与导出的报表中显示。",
-    "inclusion_relationship_hint": "💡 提示: 统计每个组串包含的单组件数量"
+    "inclusion_relationship_hint": "💡 提示: 统计每个组串包含的单组件数量",
+    "missing_panel_hint": "💡 提示: 自动圈出组串内缺失的组件",
+    "misaligned_panel_hint": "💡 提示: 检测组件旋转或移位"
   },
   "MAIN_HEADERS": {
     "video_image_detection_system": "📷 视频/图片检测系统",
@@ -369,7 +373,9 @@
     },
     "Segmentation": {
       "component": "单组件",
-      "string": "组串"
+      "string": "组串",
+      "missing_panel": "光伏板缺失",
+      "misaligned_panel": "光伏板移位"
     }
   }
 }

--- a/src/utils.py
+++ b/src/utils.py
@@ -796,3 +796,125 @@ def compute_inclusion_relations(detections):
         records.append([f"string_{s_idx}", count])
 
     return pd.DataFrame(records, columns=["组串编号", "包含组件数"])
+
+
+def compute_missing_panels(detections, image_shape, min_area=1000):
+    """Detect regions inside each string bbox that lack components."""
+
+    height, width = image_shape[:2]
+    strings = []
+    components = []
+
+    for det in detections:
+        if det.get("class_name") == "string":
+            strings.append(det)
+        elif det.get("class_name") == "component":
+            components.append(det)
+
+    missing = []
+    for s in strings:
+        x1_s, y1_s, x2_s, y2_s = s["bbox"]
+        mask = np.zeros((height, width), dtype=np.uint8)
+        cv2.rectangle(mask, (x1_s, y1_s), (x2_s, y2_s), 255, -1)
+
+        for c in components:
+            x1_c, y1_c, x2_c, y2_c = c["bbox"]
+            if x1_c >= x1_s and y1_c >= y1_s and x2_c <= x2_s and y2_c <= y2_s:
+                cv2.rectangle(mask, (x1_c, y1_c), (x2_c, y2_c), 0, -1)
+
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        for cnt in contours:
+            area = cv2.contourArea(cnt)
+            x, y, w, h = cv2.boundingRect(cnt)
+            if area >= min_area and not (x == x1_s and y == y1_s and x + w == x2_s and y + h == y2_s):
+                missing.append(
+                    {
+                        "class_name": "missing_panel",
+                        "bbox": [x, y, x + w, y + h],
+                        "score": 1.0,
+                        "class_id": len(detections),
+                        "mask": cnt.reshape(-1, 2),
+                    }
+                )
+
+    return missing
+
+
+def compute_misaligned_panels(detections, angle_threshold=5.0, center_ratio=0.2):
+    """Detect misaligned components within strings.
+
+    Args:
+        detections (list): Detection results with component and string objects.
+        angle_threshold (float): Allowed angle deviation in degrees.
+        center_ratio (float): Allowed center deviation ratio.
+
+    Returns:
+        list: misaligned component detections.
+    """
+
+    strings = []
+    components = []
+    for det in detections:
+        if det.get("class_name") == "string":
+            strings.append(det)
+        elif det.get("class_name") == "component":
+            components.append(det)
+
+    misaligned = []
+
+    for s in strings:
+        x1_s, y1_s, x2_s, y2_s = s["bbox"]
+        comps_in_string = []
+        for c in components:
+            x1_c, y1_c, x2_c, y2_c = c["bbox"]
+            if x1_c >= x1_s and y1_c >= y1_s and x2_c <= x2_s and y2_c <= y2_s:
+                mask = np.array(c.get("mask", []), dtype=np.int32)
+                if mask.size == 0:
+                    mask = np.array(
+                        [[x1_c, y1_c], [x2_c, y1_c], [x2_c, y2_c], [x1_c, y2_c]],
+                        dtype=np.int32,
+                    )
+                rect = cv2.minAreaRect(mask)
+                (cx, cy), (_, _), angle = rect
+                comps_in_string.append({
+                    "det": c,
+                    "center": (cx, cy),
+                    "angle": angle,
+                })
+
+        if not comps_in_string:
+            continue
+
+        angles = [c["angle"] for c in comps_in_string]
+        median_angle = np.median(angles)
+
+        centers = np.array([c["center"] for c in comps_in_string])
+        centers_sorted = centers[centers[:, 0].argsort()]
+
+        if len(centers_sorted) > 1:
+            spacings = np.diff(centers_sorted[:, 0])
+            median_space = np.median(spacings)
+        else:
+            median_space = 0
+
+        for idx, comp in enumerate(comps_in_string):
+            angle_dev = abs(comp["angle"] - median_angle)
+            center_dev = 0
+            if median_space > 0:
+                expected_x = centers_sorted[0, 0] + idx * median_space
+                center_dev = abs(comp["center"][0] - expected_x)
+
+            if angle_dev > angle_threshold or (
+                median_space > 0 and center_dev > center_ratio * median_space
+            ):
+                misaligned.append(
+                    {
+                        "class_name": "misaligned_panel",
+                        "bbox": comp["det"]["bbox"],
+                        "score": 1.0,
+                        "class_id": len(detections) + len(misaligned),
+                        "mask": comp["det"].get("mask"),
+                    }
+                )
+
+    return misaligned

--- a/src/web.py
+++ b/src/web.py
@@ -38,6 +38,8 @@ from utils import (
     fill_largest_polygon_white,
     extract_gps_info,
     compute_inclusion_relations,
+    compute_missing_panels,
+    compute_misaligned_panels,
 )
 from datetime import datetime
 from auth import verify_token, get_access_token
@@ -323,6 +325,8 @@ class Detection_UI:
         self.gps_time_placeholder = None
         self.inclusion_table_placeholder = None
         self.show_inclusion = False
+        self.show_missing_panel = False
+        self.show_misaligned_panel = False
 
         self.new_width = 1080
         self.new_height = int(self.new_width * (9 / 16))
@@ -740,6 +744,18 @@ class Detection_UI:
             value=False,
         )
         st.sidebar.caption(get_sidebar_hint("inclusion_relationship_hint"))
+
+        self.show_missing_panel = st.sidebar.checkbox(
+            get_sidebar_label("show_missing_panel"),
+            value=False,
+        )
+        st.sidebar.caption(get_sidebar_hint("missing_panel_hint"))
+
+        self.show_misaligned_panel = st.sidebar.checkbox(
+            get_sidebar_label("show_misaligned_panel"),
+            value=False,
+        )
+        st.sidebar.caption(get_sidebar_hint("misaligned_panel_hint"))
 
         export_options = get_sidebar_option("export_formats")
         # 根据用户选择的导出格式设置文件后缀
@@ -2303,6 +2319,16 @@ class Detection_UI:
         # 如果有有效的检测结果
         if det is not None and len(det):
             det_info = self.model.postprocess(pred)  # 后处理预测结果
+            if (
+                self.show_missing_panel
+                and self.model_type == get_system_default("model_type_segmentation")
+            ):
+                det_info.extend(compute_missing_panels(det_info, image.shape))
+            if (
+                self.show_misaligned_panel
+                and self.model_type == get_system_default("model_type_segmentation")
+            ):
+                det_info.extend(compute_misaligned_panels(det_info))
             if len(det_info):
                 disp_res = ResultLogger()
                 res = None
@@ -2334,18 +2360,29 @@ class Detection_UI:
                             )
 
                     # Ensure cls_id is within bounds
-                    if cls_id >= len(self.colors):
-                        st.warning(
-                            get_warning_message(
-                                "index_out_of_range_warning", cls_id=cls_id
-                            )
-                        )
-                        color = (255, 0, 0)  # 默认红色
+                    if name == "missing_panel":
+                        color = Segmentation_class_colors.get("missing_panel", (255, 0, 255))
+                        draw_flag = self.show_missing_panel
+                        chinese_name = "光伏板缺失"
+                    elif name == "misaligned_panel":
+                        color = Segmentation_class_colors.get("misaligned_panel", (255, 165, 0))
+                        draw_flag = self.show_misaligned_panel
+                        chinese_name = "光伏板移位"
                     else:
-                        color = self.colors[cls_id]
+                        if cls_id >= len(self.colors):
+                            st.warning(
+                                get_warning_message(
+                                    "index_out_of_range_warning", cls_id=cls_id
+                                )
+                            )
+                            color = (255, 0, 0)  # 默认红色
+                        else:
+                            color = self.colors[cls_id]
+                        chinese_name = self.cls_name.get(name, "未知类别")
+                        draw_flag = name in self.selected_classes
 
                     # 🔧 确保类别匹配逻辑正确
-                    if name in self.selected_classes:
+                    if draw_flag:
                         # 绘制检测框、标签和面积信息
                         if not is_api:
                             image, aim_frame_area = draw_detections(
@@ -2365,9 +2402,6 @@ class Detection_UI:
                                 is_api=True,
                                 rectangle_bbox=self.rectangle_bounding_output,
                             )
-
-                        # 获取中文名
-                        chinese_name = self.cls_name.get(name, "未知类别")
 
                         res = disp_res.concat_results(
                             name,

--- a/tests/test_misaligned_panels.py
+++ b/tests/test_misaligned_panels.py
@@ -1,0 +1,26 @@
+import numpy as np
+from src.utils import compute_misaligned_panels
+
+
+def test_compute_misaligned_panels_basic():
+    detections = [
+        {"class_name": "string", "bbox": [0, 0, 200, 100], "score": 1.0, "class_id": 0},
+        {
+            "class_name": "component",
+            "bbox": [0, 0, 50, 100],
+            "score": 1.0,
+            "class_id": 1,
+            "mask": np.array([[0, 0], [50, 0], [50, 100], [0, 100]]),
+        },
+        {
+            "class_name": "component",
+            "bbox": [60, 0, 110, 100],
+            "score": 1.0,
+            "class_id": 2,
+            "mask": np.array([[60, 0], [110, 10], [100, 100], [50, 90]]),
+        },
+    ]
+
+    misaligned = compute_misaligned_panels(detections, angle_threshold=5, center_ratio=0.1)
+    assert any(det["class_name"] == "misaligned_panel" for det in misaligned)
+

--- a/tests/test_missing_panels.py
+++ b/tests/test_missing_panels.py
@@ -1,0 +1,13 @@
+import numpy as np
+from src.utils import compute_missing_panels
+
+
+def test_compute_missing_panels_basic():
+    detections = [
+        {"class_name": "string", "bbox": [0, 0, 100, 100], "score": 1.0, "class_id": 0},
+        {"class_name": "component", "bbox": [0, 0, 50, 100], "score": 1.0, "class_id": 1},
+    ]
+    missing = compute_missing_panels(detections, (100, 100, 3), min_area=10)
+    assert len(missing) == 1
+    m_bbox = missing[0]["bbox"]
+    assert m_bbox == [50, 0, 100, 100]


### PR DESCRIPTION
## Summary
- implement `compute_misaligned_panels` to detect rotated or shifted modules
- add sidebar controls and translations for misaligned detection
- draw misaligned results with new color
- update color mappings for segmentation
- unit test for misaligned panel computation

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not connect to pypi)*
- `flake8 src` *(fails: command not found)*
- `mypy src` *(fails with many errors)*
- `pytest tests/ --cov=src --cov-report=term-missing` *(fails: unrecognized arguments)*
- `pytest tests/` *(errors during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6874ab4e4e18832c9765879527ba9585